### PR TITLE
Fix: write imported radio settings to the radio (fixes #148)

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -214,7 +214,11 @@ export const Toolbar: React.FC = () => {
       }
       setAnalogEmergencies(codeplugData.analogEmergencies);
       if (codeplugData.radioSettings) {
-        setRadioSettings(codeplugData.radioSettings);
+        // Mark all imported settings as changed so a subsequent Write pushes
+        // the full block to the radio. Without this, imported settings load
+        // into the UI but never get written (issue #2 — the write path only
+        // encodes changedFields, which is empty right after import).
+        setRadioSettings(codeplugData.radioSettings, { markAllChanged: true });
       }
       setRadioInfo(codeplugData.radioInfo ?? null);
       setMessages(codeplugData.messages ?? []);

--- a/src/store/radioSettingsStore.ts
+++ b/src/store/radioSettingsStore.ts
@@ -5,7 +5,11 @@ interface RadioSettingsState {
   settings: RadioSettings | null;
   originalSettings: RadioSettings | null; // Store original settings from radio
   changedFields: Set<string>; // Track which fields have been modified
-  setSettings: (settings: RadioSettings | null) => void;
+  // markAllChanged: when true (used by the codeplug IMPORT path), every
+  // settings key is flagged as changed so a subsequent Write pushes the full
+  // imported block. Without it, imported settings never reach the radio
+  // because the write path only encodes changedFields (see issue #2).
+  setSettings: (settings: RadioSettings | null, opts?: { markAllChanged?: boolean }) => void;
   updateSettings: (updates: Partial<RadioSettings>) => void;
   hasChanges: () => boolean; // Check if any settings have been modified
   getChangedFields: () => string[]; // Get list of changed field names
@@ -50,10 +54,14 @@ export const useRadioSettingsStore = create<RadioSettingsState>((set, get) => ({
   settings: null,
   originalSettings: null,
   changedFields: new Set<string>(),
-  setSettings: (settings) => set({ 
+  setSettings: (settings, opts) => set({
     settings,
     originalSettings: settings ? JSON.parse(JSON.stringify(settings)) : null, // Deep clone
-    changedFields: new Set<string>(), // Reset changes when loading new settings
+    // Default (read-from-radio): no fields dirty. Import path passes
+    // markAllChanged so every field writes back (issue #2).
+    changedFields: settings && opts?.markAllChanged
+      ? new Set<string>(Object.keys(settings))
+      : new Set<string>(),
   }),
   updateSettings: (updates) =>
     set((state) => {

--- a/tests/unit/radioSettingsStore.test.ts
+++ b/tests/unit/radioSettingsStore.test.ts
@@ -188,3 +188,27 @@ describe('hasChanges / getChangedFields', () => {
     expect(useRadioSettingsStore.getState().getChangedFields()).toContain('squelchLevel');
   });
 });
+
+describe('setSettings markAllChanged (import write-gate fix, issue #2)', () => {
+  it('default (read-from-radio) marks no fields changed', () => {
+    useRadioSettingsStore.getState().setSettings(makeSettings({ squelchLevel: 3, backlightBrightness: 4 }));
+    expect(useRadioSettingsStore.getState().getChangedFields()).toHaveLength(0);
+    expect(useRadioSettingsStore.getState().hasChanges()).toBe(false);
+  });
+
+  it('markAllChanged flags every settings key so an imported codeplug writes back', () => {
+    const s = makeSettings({ squelchLevel: 3, backlightBrightness: 4 });
+    useRadioSettingsStore.getState().setSettings(s, { markAllChanged: true });
+    const changed = useRadioSettingsStore.getState().getChangedFields();
+    // every own key of the imported settings should be marked changed
+    for (const key of Object.keys(s)) {
+      expect(changed).toContain(key);
+    }
+    expect(useRadioSettingsStore.getState().hasChanges()).toBe(true);
+  });
+
+  it('markAllChanged with null settings marks nothing', () => {
+    useRadioSettingsStore.getState().setSettings(null, { markAllChanged: true });
+    expect(useRadioSettingsStore.getState().getChangedFields()).toHaveLength(0);
+  });
+});

--- a/tests/unit/radioSettingsStore.test.ts
+++ b/tests/unit/radioSettingsStore.test.ts
@@ -189,7 +189,7 @@ describe('hasChanges / getChangedFields', () => {
   });
 });
 
-describe('setSettings markAllChanged (import write-gate fix, issue #2)', () => {
+describe('setSettings markAllChanged (import write-gate fix)', () => {
   it('default (read-from-radio) marks no fields changed', () => {
     useRadioSettingsStore.getState().setSettings(makeSettings({ squelchLevel: 3, backlightBrightness: 4 }));
     expect(useRadioSettingsStore.getState().getChangedFields()).toHaveLength(0);


### PR DESCRIPTION
Fixes #148.

## Problem
Imported codeplug settings load into the UI but are never written on Write — the radio keeps its old settings. Concrete case on a DM-32UV: an imported power-on/boot screen shows in NeonPlug but never applies to the radio. Verified on hardware.

## Root cause
The settings write path only encodes `changedFields`. On import, `setSettings` resets `changedFields` to empty, so Write pushes an empty settings delta and nothing reaches the radio. (Manually editing a field in the UI marks it changed and works — the current workaround.)

## Fix
Add a `markAllChanged` option to `setSettings`; the import handler passes it so every imported settings key is flagged changed and Write pushes the full block. Read-from-radio path unchanged (delta-write preserved for normal edits).

- `src/store/radioSettingsStore.ts`: `setSettings(settings, { markAllChanged })`
- `src/components/layout/Toolbar.tsx`: import passes `markAllChanged: true`
- `tests/unit/radioSettingsStore.test.ts`: 3 new cases

No protocol/wire changes.

## Verification
- 22/22 `radioSettingsStore` unit tests pass (3 new).
- **On real DM-32UV hardware:** imported a codeplug with a power-on line change → Write → the boot screen applied (previously it was skipped and the radio kept the old screen).