### PR TITLE
Expose live talkaround state in the channel editor and table

### DIFF
--- a/src/components/channels/ChannelEditModal.tsx
+++ b/src/components/channels/ChannelEditModal.tsx
@@ -681,6 +681,22 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   <p className="text-xs text-cool-gray">Prevent direct communication without repeater</p>
                 </div>
               </label>
+
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={editedChannel.unknown1A_3}
+                  onChange={(e) => handleChange('unknown1A_3', e.target.checked)}
+                  className="w-4 h-4 accent-neon-cyan flex-shrink-0"
+                />
+                <div>
+                  <span className="text-sm text-white font-medium">Talkaround Engaged</span>
+                  <p className="text-xs text-cool-gray">
+                    Live talkaround state — not shown in OEM CPS either. Can silently carry over from a
+                    channel's previous contents; check this is off before writing if you don't want it.
+                  </p>
+                </div>
+              </label>
             </div>
           </section>
 

--- a/src/components/channels/ChannelRow.tsx
+++ b/src/components/channels/ChannelRow.tsx
@@ -454,6 +454,14 @@ export const ChannelRow: React.FC<ChannelRowProps> = React.memo(({
           className="checkbox-theme"
         />
       </td>
+      <td className="px-2 py-2 text-center" title="Live talkaround state — not shown in OEM CPS either">
+        <input
+          type="checkbox"
+          checked={channel.unknown1A_3}
+          onChange={(e) => handleCellChange(channel.number, 'unknown1A_3', e.target.checked)}
+          className="checkbox-theme"
+        />
+      </td>
       <td className="px-2 py-2 text-center">
         <input
           type="checkbox"

--- a/src/components/channels/ChannelsTab.tsx
+++ b/src/components/channels/ChannelsTab.tsx
@@ -11,7 +11,7 @@ import type { Channel } from '../../models/Channel';
 const isVFOChannel = (n: number) => n === 4001 || n === 4002;
 
 export const ChannelsTab: React.FC = () => {
-  const { channels, addChannel, deleteChannels } = useChannelsStore();
+  const { channels, addChannel, deleteChannels, setChannels } = useChannelsStore();
   const { settings: radioSettings } = useRadioSettingsStore();
   const { caps } = useRadioCapabilities();
   const supportsVfoChannels = caps?.supportsVfoChannels === true;
@@ -67,6 +67,19 @@ export const ChannelsTab: React.FC = () => {
   }, [deleteChannels]);
 
   const handleClearSelection = useCallback(() => setSelectedChannelNumbers(new Set()), []);
+
+  // "Talkaround Engaged" (unknown1A_3) reflects live radio state and isn't shown by OEM CPS
+  // either — it can silently carry over from a channel's previous contents. This gives a
+  // one-click way to confirm it's off everywhere before writing.
+  const talkaroundEngagedCount = useMemo(
+    () => channels.filter(ch => ch.unknown1A_3).length,
+    [channels]
+  );
+  const [clearTalkaroundOpen, setClearTalkaroundOpen] = useState(false);
+  const handleClearTalkaroundConfirm = useCallback(() => {
+    setChannels(channels.map(ch => ch.unknown1A_3 ? { ...ch, unknown1A_3: false } : ch));
+    setClearTalkaroundOpen(false);
+  }, [channels, setChannels]);
 
   // VFO A/B as channels 4001/4002 — DM-32 only; UV5R-Mini and other radios do not have these in the channel list
   const vfoChannels = useMemo(() => {
@@ -137,6 +150,15 @@ export const ChannelsTab: React.FC = () => {
           >
             + Add
           </button>
+          {talkaroundEngagedCount > 0 && (
+            <button
+              onClick={() => setClearTalkaroundOpen(true)}
+              className="px-2 py-1 text-xs text-cool-gray hover:text-neon-cyan border border-neon-cyan border-opacity-20 hover:border-opacity-50 rounded transition-colors focus:outline-none"
+              title="Clear the live talkaround-engaged state on every channel that has it set"
+            >
+              Clear Talkaround ({talkaroundEngagedCount})
+            </button>
+          )}
         </div>
       </div>
       <div className="mb-3 flex items-center gap-3 shrink-0">
@@ -202,6 +224,15 @@ export const ChannelsTab: React.FC = () => {
         message={`Delete ${pendingDeleteCount} selected ${formatPlural(pendingDeleteCount, 'channel')}?`}
         confirmLabel="Delete"
         variant="danger"
+      />
+      <ConfirmModal
+        isOpen={clearTalkaroundOpen}
+        onClose={() => setClearTalkaroundOpen(false)}
+        onConfirm={handleClearTalkaroundConfirm}
+        title="Clear Talkaround"
+        message={`Turn off the live talkaround-engaged state on ${talkaroundEngagedCount} ${formatPlural(talkaroundEngagedCount, 'channel')}?`}
+        confirmLabel="Clear"
+        variant="default"
       />
     </div>
   );

--- a/src/components/channels/ChannelsTable.tsx
+++ b/src/components/channels/ChannelsTable.tsx
@@ -254,7 +254,8 @@ export const ChannelsTable: React.FC<ChannelsTableProps> = ({
             <th className="px-2 py-2 text-left text-neon-cyan font-bold min-w-[75px]" title="Transmit tone (CTCSS/DCS)">TX Tone</th>
             <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[30px]" title="Lone Worker">LW</th>
             <th className="px-2 py-2 text-left text-neon-cyan font-bold min-w-[50px]" title="Scan list assignment">Scan List</th>
-            <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Free to Air">FTA</th>
+            <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Forbid Talkaround (CPS permission — not the live state)">FTA</th>
+            <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Talkaround engaged (live state) — not shown in OEM CPS either; can silently carry over from a channel's previous contents">TA</th>
             <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Emergency">Emerg</th>
             <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Emergency acknowledge">Emerg Ack</th>
             <th className="px-2 py-2 text-left text-neon-cyan font-bold min-w-[52px]" title="Emergency ID">Emerg ID</th>


### PR DESCRIPTION
NeonPlug already models and round-trips byte 0x1A bit 3 (unknown1A_3) but never surfaced it in the UI, and neither does the OEM CPS. In practice this bit reflects whether talkaround is currently engaged on the radio (distinct from bit 7, "Forbid Talkaround", which is a CPS-level permission flag already exposed) — confirmed by manually engaging talkaround on hardware and observing the bit change on read-back. Since NeonPlug never writes this block unless a channel is otherwise touched, the OEM CPS leaves it untouched too, and it silently carries over whatever a channel's memory slot previously held (including onto a brand new channel reusing that slot).

Also fixes a pre-existing mislabel: the "FTA" column header's tooltip said "Free to Air" but the checkbox underneath it was actually bound to forbidTalkaround.

Adds:
- A "Talkaround Engaged" checkbox next to Forbid Talkaround in the channel editor and a "TA" column in the channels table, both bound to unknown1A_3, labeled to make clear this is reverse-engineered and not shown by the OEM CPS either.
- A "Clear Talkaround (N)" bulk action in the Channels tab toolbar (shown only when at least one channel has it set) to turn it off everywhere in one click before writing.