### PR TITLE
Fix write-time channel filter silently corrupting zones/scan lists

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import type { CodeplugData } from './services/codeplugExport';
 import { sampleChannels, sampleContacts, sampleZones } from './utils/sampleData';
 import { setLogStore, logger, LogLevel } from './utils/protocolLogger';
 import { useLogStore } from './store/logStore';
+import { compactChannelNumbers, remapChannelNumbers, remapChannelNumber } from './utils/channelHelpers';
 
 function App() {
   const [activeTab, setActiveTab] = useState('channels');
@@ -140,9 +141,24 @@ function App() {
   };
 
   const applyCodeplugToStores = (codeplugData: CodeplugData) => {
-    setChannels(codeplugData.channels);
-    setZones(codeplugData.zones);
-    setScanLists(codeplugData.scanLists);
+    // Loaded files can predate the read-time gap fix (or be hand-edited), so channel
+    // numbers may not be a contiguous 1..N matching array order. Compact here too and
+    // carry the mapping into zones/scan lists — see compactChannelNumbers for why this
+    // matters (the radio write path packs channels by array position, not .number).
+    const { channels, oldToNew, hadGaps } = compactChannelNumbers(codeplugData.channels);
+    setChannels(channels);
+    setZones(hadGaps
+      ? codeplugData.zones.map(z => ({ ...z, channels: remapChannelNumbers(z.channels, oldToNew) }))
+      : codeplugData.zones);
+    setScanLists(hadGaps
+      ? codeplugData.scanLists.map(sl => ({
+          ...sl,
+          channels: remapChannelNumbers(sl.channels, oldToNew),
+          priorityChannel1: remapChannelNumber(sl.priorityChannel1, oldToNew),
+          priorityChannel2: remapChannelNumber(sl.priorityChannel2, oldToNew),
+          designatedTxChannel: remapChannelNumber(sl.designatedTxChannel, oldToNew),
+        }))
+      : codeplugData.scanLists);
     setContacts(codeplugData.contacts);
     setDigitalEmergencies(codeplugData.digitalEmergencies);
     if (codeplugData.digitalEmergencyConfig) {

--- a/src/components/channels/ChannelEditModal.tsx
+++ b/src/components/channels/ChannelEditModal.tsx
@@ -6,7 +6,7 @@ import type { EncryptionKey } from '../../models/EncryptionKey';
 import type { QuickContact } from '../../models/QuickContact';
 import type { AnalogEmergency } from '../../models/AnalogEmergency';
 import { CTCSS_FREQUENCIES, DCS_CODES, formatCTCSSFrequency, formatDCSCode } from '../../utils/ctcssConstants';
-import { isNoTxFrequency, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
+import { isNoTxChannel } from '../../services/validation/frequencyValidator';
 import { validateChannel, type ValidationError } from '../../services/validation/channelValidator';
 import type { RadioBandLimits } from '../../types/radioCapabilities';
 
@@ -194,13 +194,13 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   <button
                     type="button"
                     onClick={() => {
-                      if (!(isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency))) {
+                      if (!(isNoTxChannel(editedChannel))) {
                         handleChange('txFrequency', editedChannel.rxFrequency);
                       }
                     }}
-                    disabled={isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency)}
+                    disabled={isNoTxChannel(editedChannel)}
                     className="p-1.5 rounded border border-neon-cyan border-opacity-30 text-neon-cyan hover:bg-neon-cyan hover:bg-opacity-10 hover:border-neon-cyan focus:outline-none focus:border-neon-cyan disabled:opacity-40 disabled:text-cool-gray disabled:border-opacity-20 disabled:cursor-not-allowed disabled:hover:bg-transparent"
-                    title={isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
+                    title={isNoTxChannel(editedChannel) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
                     aria-label="Copy RX to TX"
                   >
                     <span className="text-sm font-bold">→</span>
@@ -210,7 +210,7 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   <label className="block text-xs font-medium text-cool-gray mb-1">
                     Transmit Frequency (MHz)
                   </label>
-                  {isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency) ? (
+                  {isNoTxChannel(editedChannel) ? (
                     <>
                       <input
                         type="text"
@@ -221,7 +221,7 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                         aria-label="No transmit"
                         className="w-full bg-deep-gray border border-neon-cyan border-opacity-20 rounded px-2 py-1 text-sm text-cool-gray opacity-60 cursor-not-allowed"
                       />
-                      <p className="text-xs text-cool-gray mt-0.5">Receive-only (87–136 MHz); TX disabled</p>
+                      <p className="text-xs text-cool-gray mt-0.5">Receive-only; TX disabled</p>
                     </>
                   ) : (
                     <>
@@ -630,7 +630,7 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   checked={editedChannel.forbidTx}
                   onChange={(e) => {
                     const next = e.target.checked;
-                    if (!next && isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency)) return;
+                    if (!next && isNoTxChannel(editedChannel)) return;
                     handleChange('forbidTx', next);
                   }}
                   className="w-4 h-4 accent-neon-cyan flex-shrink-0"

--- a/src/components/channels/ChannelRow.tsx
+++ b/src/components/channels/ChannelRow.tsx
@@ -6,7 +6,7 @@ import type { EncryptionKey } from '../../models/EncryptionKey';
 import type { QuickContact } from '../../models/QuickContact';
 import type { DMRRadioID } from '../../models/DMRRadioID';
 import { CTCSS_FREQUENCIES, DCS_CODES, formatCTCSSFrequency, formatDCSCode } from '../../utils/ctcssConstants';
-import { isNoTxFrequency, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
+import { isNoTxChannel } from '../../services/validation/frequencyValidator';
 
 export const isVFOChannel = (channelNumber: number): boolean =>
   channelNumber === 4001 || channelNumber === 4002;
@@ -162,20 +162,20 @@ export const ChannelRow: React.FC<ChannelRowProps> = React.memo(({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            if (!(isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency))) {
+            if (!(isNoTxChannel(channel))) {
               handleCellChange(channel.number, 'txFrequency', channel.rxFrequency);
             }
           }}
-          disabled={isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency)}
+          disabled={isNoTxChannel(channel)}
           className="p-1 rounded border border-neon-cyan border-opacity-30 text-xs font-bold disabled:opacity-40 disabled:text-cool-gray disabled:border-opacity-20 disabled:cursor-not-allowed text-neon-cyan hover:bg-neon-cyan hover:bg-opacity-10 disabled:hover:bg-transparent"
-          title={isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
+          title={isNoTxChannel(channel) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
           aria-label="Copy RX to TX"
         >
           →
         </button>
       </td>
       <td className="px-2 py-2">
-        {isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency) ? (
+        {isNoTxChannel(channel) ? (
           <input
             type="text"
             readOnly
@@ -253,7 +253,7 @@ export const ChannelRow: React.FC<ChannelRowProps> = React.memo(({
           checked={channel.forbidTx}
           onChange={(e) => {
             const next = e.target.checked;
-            if (!next && isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency)) return;
+            if (!next && isNoTxChannel(channel)) return;
             handleCellChange(channel.number, 'forbidTx', next);
           }}
           className="checkbox-theme"

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -24,6 +24,7 @@ import { useAlert } from '../../hooks/useAlert';
 import { ReadProgressModal } from '../ui/ReadProgressModal';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { isWebSerialSupported } from '../../utils/browserSupport';
+import { compactChannelNumbers, remapChannelNumbers, remapChannelNumber } from '../../utils/channelHelpers';
 
 export const Toolbar: React.FC = () => {
   const { channels, setChannels } = useChannelsStore();
@@ -202,11 +203,27 @@ export const Toolbar: React.FC = () => {
       // Lazy load codeplug import when needed
       const { importCodeplug } = await import('../../services/codeplugExport');
       const codeplugData = await importCodeplug(file);
-      
+
+      // Loaded files can predate the read-time gap fix (or be hand-edited), so channel
+      // numbers may not be a contiguous 1..N matching array order. Compact here too and
+      // carry the mapping into zones/scan lists — see compactChannelNumbers for why this
+      // matters (the radio write path packs channels by array position, not .number).
+      const { channels, oldToNew, hadGaps } = compactChannelNumbers(codeplugData.channels);
+
       // Populate all stores with imported data
-      setChannels(codeplugData.channels);
-      setZones(codeplugData.zones);
-      setScanLists(codeplugData.scanLists);
+      setChannels(channels);
+      setZones(hadGaps
+        ? codeplugData.zones.map(z => ({ ...z, channels: remapChannelNumbers(z.channels, oldToNew) }))
+        : codeplugData.zones);
+      setScanLists(hadGaps
+        ? codeplugData.scanLists.map(sl => ({
+            ...sl,
+            channels: remapChannelNumbers(sl.channels, oldToNew),
+            priorityChannel1: remapChannelNumber(sl.priorityChannel1, oldToNew),
+            priorityChannel2: remapChannelNumber(sl.priorityChannel2, oldToNew),
+            designatedTxChannel: remapChannelNumber(sl.designatedTxChannel, oldToNew),
+          }))
+        : codeplugData.scanLists);
       setContacts(codeplugData.contacts);
       setDigitalEmergencies(codeplugData.digitalEmergencies);
       if (codeplugData.digitalEmergencyConfig) {

--- a/src/hooks/useRadioConnection.ts
+++ b/src/hooks/useRadioConnection.ts
@@ -23,6 +23,8 @@ import type { Zone } from '../models/Zone';
 import type { ScanList } from '../models/ScanList';
 import { isValidChannelFrequency } from '../services/validation/frequencyValidator';
 import { parseBootImageHeader } from '../utils/bootImage';
+import { compactChannelNumbers, remapChannelNumbers, remapChannelNumber } from '../utils/channelHelpers';
+import { log } from '../utils/protocolLogger';
 
 /** Augment error message when tab was hidden during a serial operation (better reporting). */
 function withVisibilityContext(message: string, tabWentHidden: boolean): string {
@@ -143,7 +145,18 @@ export function useRadioConnection() {
       }
 
       onProgress?.(20, 'Parsing channels...', steps[4]);
-      const channels = await proto.readChannels();
+      const rawChannels = await proto.readChannels();
+
+      // Blank slots on the radio are skipped without reserving their number, so
+      // channel.number can come back with gaps relative to array order. The write
+      // path packs channels purely by array position (ignoring .number), and
+      // zones/scan lists reference channels by raw .number — so an uncompacted gap
+      // causes the next write to silently shift channels into the wrong physical
+      // slot. Compact to 1..N here and carry the mapping into zones/scan lists below.
+      const { channels, oldToNew, hadGaps } = compactChannelNumbers(rawChannels);
+      if (hadGaps) {
+        log.warn(`Channel numbers had gaps (likely blank slots on the radio) — renumbered ${rawChannels.length} channels to a contiguous 1..${channels.length} sequence`, 'Connection');
+      }
       setChannels(channels);
 
       // Enrich radioInfo with firmware from cached image (UV5R-Mini and DM-32UV)
@@ -154,7 +167,16 @@ export function useRadioConnection() {
       }
 
       if (dm32) {
-        setRawChannelData(dm32.rawChannelData);
+        let rawChannelData = dm32.rawChannelData;
+        if (hadGaps) {
+          const remapped: typeof dm32.rawChannelData = new Map();
+          for (const [oldNum, raw] of rawChannelData.entries()) {
+            const newNum = oldToNew.get(oldNum);
+            if (newNum !== undefined) remapped.set(newNum, raw);
+          }
+          rawChannelData = remapped;
+        }
+        setRawChannelData(rawChannelData);
         setBlockMetadata(new Map(dm32.blockMetadata));
         setBlockData(new Map(dm32.blockData));
       }
@@ -168,13 +190,25 @@ export function useRadioConnection() {
       onProgress?.(70, 'Parsing configuration from cache...', steps[5]);
 
       if (caps?.supportsZones) {
-        const zones = await proto.readZones();
+        let zones = await proto.readZones();
+        if (hadGaps) {
+          zones = zones.map(z => ({ ...z, channels: remapChannelNumbers(z.channels, oldToNew) }));
+        }
         setZones(zones);
         if (dm32) setRawZoneData(dm32.rawZoneData);
       }
 
       if (caps?.supportsScanLists) {
-        const scanLists = await proto.readScanLists();
+        let scanLists = await proto.readScanLists();
+        if (hadGaps) {
+          scanLists = scanLists.map(sl => ({
+            ...sl,
+            channels: remapChannelNumbers(sl.channels, oldToNew),
+            priorityChannel1: remapChannelNumber(sl.priorityChannel1, oldToNew),
+            priorityChannel2: remapChannelNumber(sl.priorityChannel2, oldToNew),
+            designatedTxChannel: remapChannelNumber(sl.designatedTxChannel, oldToNew),
+          }));
+        }
         setScanLists(scanLists);
         if (dm32) setRawScanListData(dm32.rawScanListData);
       }
@@ -557,32 +591,39 @@ export function useRadioConnection() {
       // Filter channels to only include those with valid frequencies (use effective model for capabilities)
       const effectiveModel = radioInfo?.model ?? selectedRadioModel ?? null;
       const bandLimits = getCapabilitiesForModel(effectiveModel)?.bandLimits;
-      const validChannels = channels.filter(ch => isValidChannelFrequency(ch, bandLimits));
-      const filteredCount = channels.length - validChannels.length;
-      
+      const rawValidChannels = channels.filter(ch => isValidChannelFrequency(ch, bandLimits));
+      const filteredCount = channels.length - rawValidChannels.length;
+
       if (filteredCount > 0) {
         console.warn(`Filtered out ${filteredCount} channel(s) with frequencies outside supported ranges`);
       }
-      
-      // Update zones to only include channel numbers that exist (never write zone refs to non-existent channels)
-      const validChannelNumbers = new Set(validChannels.map(ch => ch.number));
+
+      // Filtering can leave gaps in channel.number relative to array order (e.g. channel 51
+      // removed, 52+ unchanged). generateChannelBlocks() packs channels purely by array
+      // position and ignores .number, so an uncompacted gap here silently shifts every
+      // subsequent channel into the wrong physical slot while zone/scan-list references
+      // still point at the old numbers. Compact first, then remap references through the
+      // same mapping (this also drops refs to channels that were actually filtered out).
+      const { channels: validChannels, oldToNew } = compactChannelNumbers(rawValidChannels);
+
       const filteredZones = zones.map(zone => {
-        const invalidRefs = zone.channels.filter(chNum => !validChannelNumbers.has(chNum));
-        if (invalidRefs.length > 0) {
+        const remapped = remapChannelNumbers(zone.channels, oldToNew);
+        const droppedCount = zone.channels.length - remapped.length;
+        if (droppedCount > 0) {
           console.warn(
-            `[Zones] Zone "${zone.name}" referenced non-existent channel(s): ${invalidRefs.join(', ')}. Removed before write to prevent radio errors.`
+            `[Zones] Zone "${zone.name}" referenced ${droppedCount} filtered-out channel(s). Removed before write to prevent radio errors.`
           );
         }
-        return {
-          ...zone,
-          channels: zone.channels.filter(chNum => validChannelNumbers.has(chNum))
-        };
+        return { ...zone, channels: remapped };
       }).filter(zone => zone.channels.length > 0); // Remove empty zones
-      
+
       // Update scan lists to only include valid channel numbers
       const filteredScanLists = scanLists.map(scanList => ({
         ...scanList,
-        channels: scanList.channels.filter(chNum => validChannelNumbers.has(chNum))
+        channels: remapChannelNumbers(scanList.channels, oldToNew),
+        priorityChannel1: remapChannelNumber(scanList.priorityChannel1, oldToNew),
+        priorityChannel2: remapChannelNumber(scanList.priorityChannel2, oldToNew),
+        designatedTxChannel: remapChannelNumber(scanList.designatedTxChannel, oldToNew),
       })).filter(scanList => scanList.channels.length > 0); // Remove empty scan lists
       
       // Use protocol for connected radio (write path)

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -8,7 +8,7 @@ import { generateZoneId } from '../../utils/zoneHelpers';
 import { OFFSET, BLOCK_SIZE, LIMITS, METADATA } from './constants';
 import { createDefaultChannel } from '../../utils/channelHelpers';
 import { log } from '../../utils/protocolLogger';
-import { NO_TX_FREQUENCY, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
+import { NO_TX_FREQUENCY, isNoTxChannel } from '../../services/validation/frequencyValidator';
 
 // --- BCD frequency and CTCSS/DCS encoding (inlined from encoding.ts) ---
 
@@ -572,8 +572,10 @@ export function encodeChannel(channel: Channel): Uint8Array {
   const rxFreqBytes = encodeBCDFrequency(channel.rxFrequency);
   data.set(rxFreqBytes, 0x10);
 
-  // TX Frequency (0x14-0x17). Use 0xFF only for RX in 87–136 MHz with Forbid TX; else encode actual TX.
-  if (isRxInNoTxBand(channel.rxFrequency) && channel.forbidTx) {
+  // TX Frequency (0x14-0x17). Use 0xFF for any receive-only (Forbid TX) channel already
+  // carrying the no-TX sentinel; else encode actual TX. Not limited to the 87-136 MHz
+  // aviation band — see isNoTxChannel().
+  if (isNoTxChannel(channel)) {
     data[0x14] = data[0x15] = data[0x16] = data[0x17] = 0xFF;
   } else {
     const txFreqBytes = encodeBCDFrequency(channel.txFrequency);

--- a/src/services/validation/channelValidator.ts
+++ b/src/services/validation/channelValidator.ts
@@ -1,6 +1,6 @@
 import type { Channel } from '../../models/Channel';
 import type { RadioBandLimits } from '../../types/radioCapabilities';
-import { isNoTxFrequency, isRxInNoTxBand } from './frequencyValidator';
+import { isNoTxChannel } from './frequencyValidator';
 import { isValidColorCode, isValidTimeSlot } from './dmrValidator';
 
 export interface ValidationError {
@@ -34,8 +34,8 @@ export function validateChannel(
   if (channel.rxFrequency <= 0) {
     errors.push({ field: 'rxFrequency', message: 'RX frequency must be greater than 0' });
   }
-  const isNoTxChannel = isRxInNoTxBand(channel.rxFrequency) && channel.forbidTx && isNoTxFrequency(channel.txFrequency);
-  if (!isNoTxChannel && channel.txFrequency <= 0) {
+  const noTxChannel = isNoTxChannel(channel);
+  if (!noTxChannel && channel.txFrequency <= 0) {
     errors.push({ field: 'txFrequency', message: 'TX frequency must be greater than 0' });
   }
 

--- a/src/services/validation/frequencyValidator.ts
+++ b/src/services/validation/frequencyValidator.ts
@@ -20,6 +20,20 @@ export function isRxInNoTxBand(rxFrequency: number): boolean {
 }
 
 /**
+ * True if this channel is receive-only with TX stored as the 0xFF sentinel.
+ *
+ * Not limited to the 87–136 MHz aviation band: real codeplugs (confirmed against OEM CPS
+ * output) use Forbid TX + the 0xFF sentinel for receive-only channels anywhere in the band
+ * (e.g. a paging monitor channel at 159 MHz), not just aviation receive. Gating this on
+ * isRxInNoTxBand() caused isValidChannelFrequency() to reject such channels outright
+ * (their leftover/sentinel TX value fails the normal band-range check), silently dropping
+ * them from writes.
+ */
+export function isNoTxChannel(channel: Channel): boolean {
+  return channel.forbidTx && isNoTxFrequency(channel.txFrequency);
+}
+
+/**
  * Check if a frequency is in the supported ranges.
  * When limits is provided (e.g. from getCapabilitiesForModel), uses those; otherwise uses default ranges.
  */
@@ -39,7 +53,7 @@ export function isValidFrequencyRange(frequency: number, limits?: RadioBandLimit
  */
 export function isValidChannelFrequency(channel: Channel, limits?: RadioBandLimits | null): boolean {
   if (channel.rxFrequency <= 0) return false;
-  if (isRxInNoTxBand(channel.rxFrequency) && channel.forbidTx && isNoTxFrequency(channel.txFrequency)) {
+  if (isNoTxChannel(channel)) {
     return isValidFrequencyRange(channel.rxFrequency, limits);
   }
   if (channel.txFrequency <= 0) return false;

--- a/src/utils/channelHelpers.ts
+++ b/src/utils/channelHelpers.ts
@@ -4,6 +4,47 @@
 
 import type { Channel } from '../models';
 
+export interface ChannelRenumberResult {
+  /** Channels renumbered to a contiguous 1..N sequence, sorted by their prior number */
+  channels: Channel[];
+  /** Prior channel.number -> new channel.number, for remapping zone/scan-list references */
+  oldToNew: Map<number, number>;
+  /** True if any renumbering actually happened (numbers weren't already 1..N matching array order) */
+  hadGaps: boolean;
+}
+
+/**
+ * Renumber channels to a contiguous 1..N sequence matching sorted order.
+ *
+ * The radio's write path (generateChannelBlocks) packs channels back-to-back purely by
+ * array position and ignores channel.number entirely; zones and scan lists then reference
+ * channels by the raw .number value. Reading skips blank slots on the radio without
+ * reserving their number, so channel.number can come back with gaps (e.g. ...50, 52, 53...
+ * if slot 51 was blank). Left uncompacted, the next write silently shifts every channel
+ * after a gap into the wrong physical slot and any zone/scan-list referencing the old
+ * numbers ends up pointing at the wrong channel. Call this right after reading channels,
+ * and remap zone/scan-list channel references with the returned oldToNew map.
+ */
+export function compactChannelNumbers(channels: Channel[]): ChannelRenumberResult {
+  const sorted = [...channels].sort((a, b) => a.number - b.number);
+  const hadGaps = sorted.some((ch, i) => ch.number !== i + 1);
+  const oldToNew = new Map(sorted.map((ch, i) => [ch.number, i + 1]));
+  const renumbered = hadGaps ? sorted.map((ch, i) => ({ ...ch, number: i + 1 })) : sorted;
+  return { channels: renumbered, oldToNew, hadGaps };
+}
+
+/** Remap a list of channel numbers (e.g. a zone's or scan list's .channels) through an oldToNew map, dropping any that no longer exist. */
+export function remapChannelNumbers(numbers: number[], oldToNew: Map<number, number>): number[] {
+  return numbers
+    .map(n => oldToNew.get(n))
+    .filter((n): n is number => n !== undefined);
+}
+
+/** Remap a single optional channel reference (e.g. a scan list's priority/designated-TX channel) through an oldToNew map. */
+export function remapChannelNumber(n: number | undefined, oldToNew: Map<number, number>): number | undefined {
+  return n === undefined ? undefined : oldToNew.get(n);
+}
+
 /**
  * Create a new channel with sensible defaults
  * All unknown fields are set to 0/false to match typical radio defaults


### PR DESCRIPTION
isValidChannelFrequency() only recognized the 0xFF "no TX" sentinel for receive-only (Forbid TX) channels whose RX frequency fell in the 87-136 MHz aviation band. A receive-only channel anywhere else in the band (e.g. a paging monitor channel) — legitimately using the same sentinel, confirmed against real OEM CPS output — got its sentinel TX value treated as a literal out-of-band frequency and the whole channel was filtered out of the write.

That filtering ran *after* channel numbers were assigned and *before* the radio write, which packs channels purely by array position and ignores channel.number. Dropping one channel without renumbering the rest meant every later channel silently shifted one physical slot, while zone/scan-list entries kept referencing the old absolute numbers — corrupting zone membership on every write that included such a channel. Root-caused with byte-level captures; see linked report.

Fixes:
- isNoTxChannel() (frequencyValidator.ts) now recognizes the sentinel for any Forbid-TX channel, not just the aviation band. Applied consistently in the validator, the DM-32UV encoder (which had the same aviation-band-only bug and would have BCD-encoded the sentinel as a literal garbage frequency), and the channel-editor UI.
- Defense in depth: compactChannelNumbers()/remapChannelNumbers() (channelHelpers.ts) renumber channels to a contiguous 1..N sequence matching array order and remap zone/scan-list channel references through the same mapping. Wired into the radio read path, the write path's post-filter step, and codeplug/CSV file imports — so any future legitimate filtering (or a codeplug with pre-existing gaps) can no longer reproduce this corruption pattern.