### PR TITLE
Preserve byte 0x1A bits 1-0 on every channel write

### DIFF
--- a/src/models/Channel.ts
+++ b/src/models/Channel.ts
@@ -31,7 +31,8 @@ export interface Channel {
   unknown1A_6_4: number;      // Bits 6-4: Unknown Setting (0-3, values ≥4 reset to 0)
   unknown1A_3: boolean;       // Bit 3: Unknown
   aprsReceive: boolean;       // Bit 2: 0=Off, 1=On
-  
+  unknown1A_1_0: number;      // Bits 1-0: Unknown, but OEM CPS writes 3 on every channel - preserve, don't zero
+
   // Emergency Settings (0x1B)
   emergencyIndicator: boolean; // Bit 7: 0=Off, 1=On
   emergencyAck: boolean;       // Bit 6: 0=Off, 1=On

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -266,12 +266,13 @@ export function parseChannel(data: Uint8Array, channelNumber: number): Channel {
   // Bits 6-4 (mask 0x70): Unknown Setting (0-3, values ≥4 reset to 0)
   // Bit 3 (mask 0x08): Unknown
   // Bit 2 (mask 0x04): APRS Receive (0=Off, 1=On)
-  // Bits 1-0 (mask 0x03): Reserved/Unknown
+  // Bits 1-0 (mask 0x03): Unknown, but OEM CPS writes 3 here on every channel - preserve, don't zero
   const talkaroundAprs = data[0x1A];
   const forbidTalkaround = (talkaroundAprs & 0x80) !== 0;
   const unknown1A_6_4 = (talkaroundAprs >> 4) & 0x07;
   const unknown1A_3 = (talkaroundAprs & 0x08) !== 0;
   const aprsReceive = (talkaroundAprs & 0x04) !== 0;
+  const unknown1A_1_0 = talkaroundAprs & 0x03;
 
   // Emergency (0x1B)
   // Bit 7: Emergency Indicator (0=Off, 1=On)
@@ -502,6 +503,7 @@ export function parseChannel(data: Uint8Array, channelNumber: number): Channel {
     scanListId,
     forbidTalkaround,
     aprsReceive,
+    unknown1A_1_0,
     emergencyIndicator,
     emergencyAck,
     emergencySystemId,
@@ -614,7 +616,7 @@ export function encodeChannel(channel: Channel): Uint8Array {
   talkaroundAprs |= ((channel.unknown1A_6_4 & 0x07) << 4) & 0x70; // Bits 6-4
   if (channel.unknown1A_3) talkaroundAprs |= 0x08; // Bit 3
   if (channel.aprsReceive) talkaroundAprs |= 0x04; // Bit 2
-  // Bits 1-0: Reserved/Unknown (preserve original value if reading, otherwise leave as 0)
+  talkaroundAprs |= channel.unknown1A_1_0 & 0x03; // Bits 1-0: preserve (OEM CPS writes 3 here)
   data[0x1A] = talkaroundAprs;
 
   // Emergency (0x1B)

--- a/src/radios/uv5rmini/channelMapping.ts
+++ b/src/radios/uv5rmini/channelMapping.ts
@@ -109,6 +109,7 @@ export function uv5rMiniRawToChannel(raw: Uv5rMiniChannelRaw): Channel {
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3,
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,

--- a/src/services/csv/csvImporter.ts
+++ b/src/services/csv/csvImporter.ts
@@ -94,6 +94,7 @@ export function importChannelsFromCSV(content: string): ImportResult {
           unknown1A_6_4: getFloat(headers, row, 'unknown1a_6_4', 0),
           unknown1A_3: getBool(headers, row, 'unknown1a_3'),
           aprsReceive: getBool(headers, row, 'aprs receive'),
+          unknown1A_1_0: getFloat(headers, row, 'unknown1a_1_0', 3),
           emergencyIndicator: getBool(headers, row, 'emergency'),
           emergencyAck: getBool(headers, row, 'emergency ack'),
           emergencySystemId: getFloat(headers, row, 'emergency id', 0),

--- a/src/utils/channelHelpers.ts
+++ b/src/utils/channelHelpers.ts
@@ -27,6 +27,7 @@ export function createDefaultChannel(overrides: Partial<Channel> = {}): Channel 
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,

--- a/src/utils/sampleData.ts
+++ b/src/utils/sampleData.ts
@@ -16,6 +16,7 @@ export const sampleChannels: Channel[] = [
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,
@@ -65,6 +66,7 @@ export const sampleChannels: Channel[] = [
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,
@@ -114,6 +116,7 @@ export const sampleChannels: Channel[] = [
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,


### PR DESCRIPTION
DM32-Protocol-Spec documents byte 0x1A bits 1-0 as reserved/unknown, but OEM CPS writes 0x3 there on every channel and it round-trips through untouched codeplugs. The channel encoder was silently zeroing these bits on every write, diverging from what the OEM CPS (and, presumably, the radio firmware) actually expects there.

Adds a tracked unknown1A_1_0 field that reads the bits on decode and writes them back unchanged on encode, defaulting new channels to 3 to match observed OEM CPS behavior.