### PR TITLE
Fix Smart Import wizard silently dropping/overwriting channels

### DIFF
--- a/src/components/import/sources/AirportSource.tsx
+++ b/src/components/import/sources/AirportSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber, selectionCardClass } from '../../../utils/importHelpers';
 import { generateAirportChannels, COMMON_AIRCRAFT_FREQUENCIES } from '../../../services/airportChannels';
 import { getAirportFrequenciesWithTypes, type AirportData } from '../../../data/airportsData';
@@ -22,8 +23,6 @@ export const AirportSource: React.FC<AirportSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [selectedAirports, setSelectedAirports] = useState<Set<number>>(new Set());
   const [airportZoneGrouping, setAirportZoneGrouping] = useState<'individual' | 'single'>('individual');
   const [includeCommonFrequencies, setIncludeCommonFrequencies] = useState(false);
@@ -79,7 +78,10 @@ export const AirportSource: React.FC<AirportSourceProps> = ({
         throw new Error('No airports selected');
       }
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Build the selected subset of common aircraft frequencies (if enabled)
       const commonFreqs = includeCommonFrequencies
@@ -99,13 +101,11 @@ export const AirportSource: React.FC<AirportSourceProps> = ({
         return;
       }
 
-      // Add channels
-      const updatedChannels = [...channels, ...result.channels];
-      setChannels(updatedChannels);
+      // Add channels — functional append, safe against concurrent add actions
+      useChannelsStore.getState().addChannels(result.channels);
 
       // Add zones (one per airport)
-      const updatedZones = [...zones, ...result.zones];
-      setZones(updatedZones);
+      useZonesStore.getState().addZones(result.zones);
 
       onGenerationResult({
         channels: result.channels.length,

--- a/src/components/import/sources/ChirpSource.tsx
+++ b/src/components/import/sources/ChirpSource.tsx
@@ -12,7 +12,7 @@ interface ChirpSourceProps {
 }
 
 export const ChirpSource: React.FC<ChirpSourceProps> = ({ onError }) => {
-  const { channels, setChannels } = useChannelsStore();
+  const { channels } = useChannelsStore();
 
   const [isImportingChirp, setIsImportingChirp] = useState(false);
   const [chirpImportResult, setChirpImportResult] = useState<{
@@ -33,14 +33,15 @@ export const ChirpSource: React.FC<ChirpSourceProps> = ({ onError }) => {
     try {
       const content = await file.text();
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const nextChannelNumber = getNextChannelNumber(useChannelsStore.getState().channels);
 
       const result = importChannelsFromChirpCSV(content, nextChannelNumber);
 
       if (result.success && result.channels) {
-        // Add imported channels
-        const newChannels = [...channels, ...result.channels];
-        setChannels(newChannels);
+        // Add imported channels — functional append, safe against concurrent add actions
+        useChannelsStore.getState().addChannels(result.channels);
 
         setChirpImportResult({
           operation: 'import',

--- a/src/components/import/sources/FixedChannelsSource.tsx
+++ b/src/components/import/sources/FixedChannelsSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
 import { getAvailableFixedChannelSets, getChannelsForSet } from '../../../services/fixedChannels';
 import { mergeChannelSetsWithExisting } from '../../../services/channelMerger';
@@ -20,8 +21,6 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [selectedFixedSets, setSelectedFixedSets] = useState<Set<string>>(new Set());
   const [isAddingFixed, setIsAddingFixed] = useState(false);
   const [expandedChannelSet, setExpandedChannelSet] = useState<string | null>(null);
@@ -38,7 +37,10 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
     onError('');
 
     try {
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Generate channels for each selected set. Each set gets a distinct
       // temporary number range — the merge mapping is keyed by these numbers,
@@ -61,7 +63,7 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
       // Merge overlaps within the new sets and dedupe against existing channels
       // (a new channel is reused only when ALL settings match an existing one).
       const { channelsToAdd, channelMapping } = mergeChannelSetsWithExisting(
-        channels,
+        currentChannels,
         channelSets,
         nextChannelNumber
       );
@@ -87,12 +89,11 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
         }
       }
 
-      // Add only new channels (not duplicates)
-      const updatedChannels = [...channels, ...channelsToAdd];
-      setChannels(updatedChannels);
+      // Add only new channels (not duplicates) — functional append, safe against
+      // concurrent add actions
+      useChannelsStore.getState().addChannels(channelsToAdd);
 
-      const updatedZones = [...zones, ...newZones];
-      setZones(updatedZones);
+      useZonesStore.getState().addZones(newZones);
 
       onGenerationResult({
         channels: channelsToAdd.length,

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { useContactsStore } from '../../../store/contactsStore';
 import { useDMRRadioIDsStore } from '../../../store/dmrRadioIdsStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
@@ -20,8 +21,6 @@ interface MmdvmSourceProps {
 }
 
 export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationResult }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-  const { contacts, setContacts } = useContactsStore();
   const { radioIds } = useDMRRadioIDsStore();
 
   const [mmdvmFrequency, setMmdvmFrequency] = useState('431.150');
@@ -59,9 +58,13 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
     onError('');
 
     try {
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh reads at click time — see RptrsSource.tsx for why these can't be
+      // values captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const currentContacts = useContactsStore.getState().contacts;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
-      const maxContactId = contacts.length > 0 ? Math.max(...contacts.map((c) => c.id)) : 0;
+      const maxContactId = currentContacts.length > 0 ? Math.max(...currentContacts.map((c) => c.id)) : 0;
       const firstContactId = maxContactId + 1;
 
       const firstDmrRadioIdIndex =
@@ -84,9 +87,9 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         zoneName: mmdvmZoneName.trim() || undefined,
       });
 
-      setContacts([...contacts, ...result.contacts]);
-      setChannels([...channels, ...result.channels]);
-      setZones([...zones, result.zone]);
+      useContactsStore.getState().addContacts(result.contacts);
+      useChannelsStore.getState().addChannels(result.channels);
+      useZonesStore.getState().addZones([result.zone]);
 
       onGenerationResult({
         channels: result.channels.length,

--- a/src/components/import/sources/RptrsSource.tsx
+++ b/src/components/import/sources/RptrsSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber, selectionCardClass } from '../../../utils/importHelpers';
 import { generateRptrsChannels } from '../../../services/rptrsChannels';
 import { mergeChannelSetsWithExisting } from '../../../services/channelMerger';
@@ -27,8 +28,6 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [rptrsSearchFilter, setRptrsSearchFilter] = useState('');
   const [selectedRptrs, setSelectedRptrs] = useState<Set<number>>(new Set());
   const [rptrsZoneGrouping, setRptrsZoneGrouping] = useState<'location' | 'single'>('location');
@@ -72,7 +71,12 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
         throw new Error('No DMR repeaters selected');
       }
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Read the live channel list at the moment of the click, not a value captured
+      // at render time — if another "Add channels" action ran since this component
+      // last rendered, a stale array here would pick colliding channel numbers and
+      // then blow away those newer channels entirely when committed below.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Generate channels and zones for selected repeaters
       const result = generateRptrsChannels(
@@ -92,11 +96,13 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       // Existing channels are never renumbered — renumbering them would break
       // every zone and scan list that references them.
       const { channelsToAdd, channelMapping } = mergeChannelSetsWithExisting(
-        channels,
+        currentChannels,
         [result.channels],
         nextChannelNumber
       );
-      setChannels([...channels, ...channelsToAdd]);
+      // Functional append: commits against whatever is in the store right now,
+      // instead of replacing it wholesale with a snapshot that may already be stale.
+      useChannelsStore.getState().addChannels(channelsToAdd);
 
       // Remap the generated zones through the merge mapping: a new channel that
       // collapsed into another (or matched an existing channel) changed number.
@@ -110,7 +116,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
           )].sort((a, b) => a - b),
         }))
         .filter(zone => zone.channels.length > 0);
-      setZones([...zones, ...remappedZones]);
+      useZonesStore.getState().addZones(remappedZones);
 
       onGenerationResult({
         channels: channelsToAdd.length,

--- a/src/components/import/sources/TaflSource.tsx
+++ b/src/components/import/sources/TaflSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
 import { generateTaflChannels } from '../../../services/taflChannels';
 import { groupTaflEntriesByName, type TaflData } from '../../../data/taflData';
@@ -24,8 +25,6 @@ export const TaflSource: React.FC<TaflSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [taflSearchFilter, setTaflSearchFilter] = useState('');
   const [selectedTaflEntries, setSelectedTaflEntries] = useState<Set<number>>(new Set());
   const [expandedTaflGroups, setExpandedTaflGroups] = useState<Set<string>>(new Set());
@@ -92,7 +91,10 @@ export const TaflSource: React.FC<TaflSourceProps> = ({
         throw new Error('No TAFL entries selected');
       }
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Generate channels and zones for selected entries
       // TAFL always uses individual zones grouped by name
@@ -108,13 +110,11 @@ export const TaflSource: React.FC<TaflSourceProps> = ({
         return;
       }
 
-      // Add channels
-      const updatedChannels = [...channels, ...result.channels];
-      setChannels(updatedChannels);
+      // Add channels — functional append, safe against concurrent add actions
+      useChannelsStore.getState().addChannels(result.channels);
 
       // Add zones
-      const updatedZones = [...zones, ...result.zones];
-      setZones(updatedZones);
+      useZonesStore.getState().addZones(result.zones);
 
       onGenerationResult({
         channels: result.channels.length,

--- a/src/store/channelsStore.ts
+++ b/src/store/channelsStore.ts
@@ -16,6 +16,8 @@ interface ChannelsState {
   setChannels: (channels: Channel[]) => void;
   setRawChannelData: (rawData: Map<number, RawChannelData>) => void;
   addChannel: (channel: Channel) => void;
+  /** Append multiple channels atomically against the latest state (safe against concurrent/rapid add actions) */
+  addChannels: (channels: Channel[]) => void;
   updateChannel: (number: number, channel: Partial<Channel>) => void;
   deleteChannel: (number: number) => void;
   /** Remove multiple channels at once and renumber; use for bulk delete so renumbering doesn't invalidate later numbers */
@@ -31,6 +33,9 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
   setRawChannelData: (rawData) => set({ rawChannelData: rawData }),
   addChannel: (channel) => set((state) => ({
     channels: [...state.channels, channel]
+  })),
+  addChannels: (newChannels) => set((state) => ({
+    channels: [...state.channels, ...newChannels]
   })),
   updateChannel: (number, updates) => set((state) => ({
     channels: state.channels.map(ch => 

--- a/src/store/contactsStore.ts
+++ b/src/store/contactsStore.ts
@@ -7,6 +7,8 @@ interface ContactsState {
   contactsLoaded: boolean; // Track if contacts have been read from radio
   setContacts: (contacts: Contact[]) => void;
   addContact: (contact: Contact) => void;
+  /** Append multiple contacts atomically against the latest state (safe against concurrent/rapid add actions) */
+  addContacts: (contacts: Contact[]) => void;
   updateContact: (id: number, contact: Partial<Contact>) => void;
   deleteContact: (id: number) => void;
   setSelectedContact: (id: number | null) => void;
@@ -23,6 +25,9 @@ export const useContactsStore = create<ContactsState>((set) => ({
   },
   addContact: (contact) => set((state) => ({
     contacts: [...state.contacts, contact]
+  })),
+  addContacts: (newContacts) => set((state) => ({
+    contacts: [...state.contacts, ...newContacts]
   })),
   updateContact: (id, updates) => set((state) => ({
     contacts: state.contacts.map(c => 

--- a/src/store/zonesStore.ts
+++ b/src/store/zonesStore.ts
@@ -14,6 +14,8 @@ interface ZonesState {
   setZones: (zones: Zone[]) => void;
   setRawZoneData: (rawData: Map<string, RawZoneData>) => void;
   addZone: (zone: Omit<Zone, 'id'>) => void;
+  /** Append multiple zones atomically against the latest state (safe against concurrent/rapid add actions) */
+  addZones: (zones: Zone[]) => void;
   updateZone: (id: string, zone: Partial<Omit<Zone, 'id'>>) => void;
   renameZone: (id: string, newName: string) => boolean;
   deleteZone: (id: string) => void;
@@ -37,6 +39,13 @@ export const useZonesStore = create<ZonesState>((set, get) => ({
     set({ zones: zonesWithIds });
   },
   setRawZoneData: (rawData) => set({ rawZoneData: rawData }),
+  addZones: (zones) => set((state) => {
+    const zonesWithIds = zones.map((z, index) => ({
+      ...z,
+      id: z.id || `zone-${Date.now()}-${index}-${Math.random().toString(36).substr(2, 9)}`
+    }));
+    return { zones: [...state.zones, ...zonesWithIds] };
+  }),
   addZone: (zone) => set((state) => {
     if (state.zones.length >= 250) {
       console.warn('Maximum of 250 zones allowed');


### PR DESCRIPTION
Each import source panel (Airport, TAFL, DMR Repeaters, Fixed Channels, MMDVM, CHIRP) read `channels` from the top-level useChannelsStore() hook at render time, computed the next channel number and merged against that snapshot, then committed with a full-array setChannels().

If two "Add X channels" actions landed close enough together that React hadn't re-rendered between them, the second action's closure held a stale, smaller channels array. It would then (a) hand out channel numbers that collided with channels added by the first action, and (b) overwrite the store with [...staleChannels, ...newChannels], silently discarding everything added since the stale snapshot. In testing this reliably dropped or overwrote dozens of existing channels when adding via the wizard to an existing codeplug — see linked report.

Fix:
- Added atomic addChannels/addZones/addContacts actions to the channels/zones/contacts stores (functional set() updates, safe against concurrent add calls).
- Each import source panel now reads channels/zones/contacts fresh via useXStore.getState() at click time instead of relying on the render-time snapshot, and commits via the new atomic append actions instead of a computed full-array replace.