### PR TITLE
Combined fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import type { CodeplugData } from './services/codeplugExport';
 import { sampleChannels, sampleContacts, sampleZones } from './utils/sampleData';
 import { setLogStore, logger, LogLevel } from './utils/protocolLogger';
 import { useLogStore } from './store/logStore';
+import { compactChannelNumbers, remapChannelNumbers, remapChannelNumber } from './utils/channelHelpers';
 
 function App() {
   const [activeTab, setActiveTab] = useState('channels');
@@ -140,9 +141,24 @@ function App() {
   };
 
   const applyCodeplugToStores = (codeplugData: CodeplugData) => {
-    setChannels(codeplugData.channels);
-    setZones(codeplugData.zones);
-    setScanLists(codeplugData.scanLists);
+    // Loaded files can predate the read-time gap fix (or be hand-edited), so channel
+    // numbers may not be a contiguous 1..N matching array order. Compact here too and
+    // carry the mapping into zones/scan lists — see compactChannelNumbers for why this
+    // matters (the radio write path packs channels by array position, not .number).
+    const { channels, oldToNew, hadGaps } = compactChannelNumbers(codeplugData.channels);
+    setChannels(channels);
+    setZones(hadGaps
+      ? codeplugData.zones.map(z => ({ ...z, channels: remapChannelNumbers(z.channels, oldToNew) }))
+      : codeplugData.zones);
+    setScanLists(hadGaps
+      ? codeplugData.scanLists.map(sl => ({
+          ...sl,
+          channels: remapChannelNumbers(sl.channels, oldToNew),
+          priorityChannel1: remapChannelNumber(sl.priorityChannel1, oldToNew),
+          priorityChannel2: remapChannelNumber(sl.priorityChannel2, oldToNew),
+          designatedTxChannel: remapChannelNumber(sl.designatedTxChannel, oldToNew),
+        }))
+      : codeplugData.scanLists);
     setContacts(codeplugData.contacts);
     setDigitalEmergencies(codeplugData.digitalEmergencies);
     if (codeplugData.digitalEmergencyConfig) {

--- a/src/components/about/AboutTab.tsx
+++ b/src/components/about/AboutTab.tsx
@@ -22,7 +22,12 @@ export const AboutTab: React.FC = () => {
     <>
     <div className="h-full overflow-y-auto">
       <div className="mb-6">
-        <h2 className="text-2xl font-bold text-neon-cyan mb-2">About NeonPlug</h2>
+        <div className="flex items-center gap-3 mb-2">
+          <h2 className="text-2xl font-bold text-neon-cyan">About NeonPlug</h2>
+          <span className="text-sm font-mono px-2 py-0.5 rounded border border-neon-cyan border-opacity-40 text-neon-cyan">
+            v{typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'}
+          </span>
+        </div>
         <p className="text-cool-gray">
           Online Digital CPS — program your radio directly from your browser.
         </p>

--- a/src/components/channels/ChannelEditModal.tsx
+++ b/src/components/channels/ChannelEditModal.tsx
@@ -681,6 +681,22 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   <p className="text-xs text-cool-gray">Prevent direct communication without repeater</p>
                 </div>
               </label>
+
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={editedChannel.unknown1A_3}
+                  onChange={(e) => handleChange('unknown1A_3', e.target.checked)}
+                  className="w-4 h-4 accent-neon-cyan flex-shrink-0"
+                />
+                <div>
+                  <span className="text-sm text-white font-medium">Talkaround Engaged</span>
+                  <p className="text-xs text-cool-gray">
+                    Live talkaround state — not shown in OEM CPS either. Can silently carry over from a
+                    channel's previous contents; check this is off before writing if you don't want it.
+                  </p>
+                </div>
+              </label>
             </div>
           </section>
 

--- a/src/components/channels/ChannelEditModal.tsx
+++ b/src/components/channels/ChannelEditModal.tsx
@@ -6,7 +6,7 @@ import type { EncryptionKey } from '../../models/EncryptionKey';
 import type { QuickContact } from '../../models/QuickContact';
 import type { AnalogEmergency } from '../../models/AnalogEmergency';
 import { CTCSS_FREQUENCIES, DCS_CODES, formatCTCSSFrequency, formatDCSCode } from '../../utils/ctcssConstants';
-import { isNoTxFrequency, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
+import { isNoTxChannel } from '../../services/validation/frequencyValidator';
 import { validateChannel, type ValidationError } from '../../services/validation/channelValidator';
 import type { RadioBandLimits } from '../../types/radioCapabilities';
 
@@ -194,13 +194,13 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   <button
                     type="button"
                     onClick={() => {
-                      if (!(isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency))) {
+                      if (!(isNoTxChannel(editedChannel))) {
                         handleChange('txFrequency', editedChannel.rxFrequency);
                       }
                     }}
-                    disabled={isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency)}
+                    disabled={isNoTxChannel(editedChannel)}
                     className="p-1.5 rounded border border-neon-cyan border-opacity-30 text-neon-cyan hover:bg-neon-cyan hover:bg-opacity-10 hover:border-neon-cyan focus:outline-none focus:border-neon-cyan disabled:opacity-40 disabled:text-cool-gray disabled:border-opacity-20 disabled:cursor-not-allowed disabled:hover:bg-transparent"
-                    title={isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
+                    title={isNoTxChannel(editedChannel) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
                     aria-label="Copy RX to TX"
                   >
                     <span className="text-sm font-bold">→</span>
@@ -210,7 +210,7 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   <label className="block text-xs font-medium text-cool-gray mb-1">
                     Transmit Frequency (MHz)
                   </label>
-                  {isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency) ? (
+                  {isNoTxChannel(editedChannel) ? (
                     <>
                       <input
                         type="text"
@@ -221,7 +221,7 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                         aria-label="No transmit"
                         className="w-full bg-deep-gray border border-neon-cyan border-opacity-20 rounded px-2 py-1 text-sm text-cool-gray opacity-60 cursor-not-allowed"
                       />
-                      <p className="text-xs text-cool-gray mt-0.5">Receive-only (87–136 MHz); TX disabled</p>
+                      <p className="text-xs text-cool-gray mt-0.5">Receive-only; TX disabled</p>
                     </>
                   ) : (
                     <>
@@ -630,7 +630,7 @@ export const ChannelEditModal: React.FC<ChannelEditModalProps> = ({
                   checked={editedChannel.forbidTx}
                   onChange={(e) => {
                     const next = e.target.checked;
-                    if (!next && isRxInNoTxBand(editedChannel.rxFrequency) && isNoTxFrequency(editedChannel.txFrequency)) return;
+                    if (!next && isNoTxChannel(editedChannel)) return;
                     handleChange('forbidTx', next);
                   }}
                   className="w-4 h-4 accent-neon-cyan flex-shrink-0"

--- a/src/components/channels/ChannelRow.tsx
+++ b/src/components/channels/ChannelRow.tsx
@@ -6,7 +6,7 @@ import type { EncryptionKey } from '../../models/EncryptionKey';
 import type { QuickContact } from '../../models/QuickContact';
 import type { DMRRadioID } from '../../models/DMRRadioID';
 import { CTCSS_FREQUENCIES, DCS_CODES, formatCTCSSFrequency, formatDCSCode } from '../../utils/ctcssConstants';
-import { isNoTxFrequency, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
+import { isNoTxChannel } from '../../services/validation/frequencyValidator';
 
 export const isVFOChannel = (channelNumber: number): boolean =>
   channelNumber === 4001 || channelNumber === 4002;
@@ -162,20 +162,20 @@ export const ChannelRow: React.FC<ChannelRowProps> = React.memo(({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            if (!(isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency))) {
+            if (!(isNoTxChannel(channel))) {
               handleCellChange(channel.number, 'txFrequency', channel.rxFrequency);
             }
           }}
-          disabled={isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency)}
+          disabled={isNoTxChannel(channel)}
           className="p-1 rounded border border-neon-cyan border-opacity-30 text-xs font-bold disabled:opacity-40 disabled:text-cool-gray disabled:border-opacity-20 disabled:cursor-not-allowed text-neon-cyan hover:bg-neon-cyan hover:bg-opacity-10 disabled:hover:bg-transparent"
-          title={isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
+          title={isNoTxChannel(channel) ? 'Receive-only (no TX)' : 'Copy RX to TX'}
           aria-label="Copy RX to TX"
         >
           →
         </button>
       </td>
       <td className="px-2 py-2">
-        {isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency) ? (
+        {isNoTxChannel(channel) ? (
           <input
             type="text"
             readOnly
@@ -253,7 +253,7 @@ export const ChannelRow: React.FC<ChannelRowProps> = React.memo(({
           checked={channel.forbidTx}
           onChange={(e) => {
             const next = e.target.checked;
-            if (!next && isRxInNoTxBand(channel.rxFrequency) && isNoTxFrequency(channel.txFrequency)) return;
+            if (!next && isNoTxChannel(channel)) return;
             handleCellChange(channel.number, 'forbidTx', next);
           }}
           className="checkbox-theme"

--- a/src/components/channels/ChannelRow.tsx
+++ b/src/components/channels/ChannelRow.tsx
@@ -454,6 +454,14 @@ export const ChannelRow: React.FC<ChannelRowProps> = React.memo(({
           className="checkbox-theme"
         />
       </td>
+      <td className="px-2 py-2 text-center" title="Live talkaround state — not shown in OEM CPS either">
+        <input
+          type="checkbox"
+          checked={channel.unknown1A_3}
+          onChange={(e) => handleCellChange(channel.number, 'unknown1A_3', e.target.checked)}
+          className="checkbox-theme"
+        />
+      </td>
       <td className="px-2 py-2 text-center">
         <input
           type="checkbox"

--- a/src/components/channels/ChannelsTab.tsx
+++ b/src/components/channels/ChannelsTab.tsx
@@ -11,7 +11,7 @@ import type { Channel } from '../../models/Channel';
 const isVFOChannel = (n: number) => n === 4001 || n === 4002;
 
 export const ChannelsTab: React.FC = () => {
-  const { channels, addChannel, deleteChannels } = useChannelsStore();
+  const { channels, addChannel, deleteChannels, setChannels } = useChannelsStore();
   const { settings: radioSettings } = useRadioSettingsStore();
   const { caps } = useRadioCapabilities();
   const supportsVfoChannels = caps?.supportsVfoChannels === true;
@@ -67,6 +67,19 @@ export const ChannelsTab: React.FC = () => {
   }, [deleteChannels]);
 
   const handleClearSelection = useCallback(() => setSelectedChannelNumbers(new Set()), []);
+
+  // "Talkaround Engaged" (unknown1A_3) reflects live radio state and isn't shown by OEM CPS
+  // either — it can silently carry over from a channel's previous contents. This gives a
+  // one-click way to confirm it's off everywhere before writing.
+  const talkaroundEngagedCount = useMemo(
+    () => channels.filter(ch => ch.unknown1A_3).length,
+    [channels]
+  );
+  const [clearTalkaroundOpen, setClearTalkaroundOpen] = useState(false);
+  const handleClearTalkaroundConfirm = useCallback(() => {
+    setChannels(channels.map(ch => ch.unknown1A_3 ? { ...ch, unknown1A_3: false } : ch));
+    setClearTalkaroundOpen(false);
+  }, [channels, setChannels]);
 
   // VFO A/B as channels 4001/4002 — DM-32 only; UV5R-Mini and other radios do not have these in the channel list
   const vfoChannels = useMemo(() => {
@@ -137,6 +150,15 @@ export const ChannelsTab: React.FC = () => {
           >
             + Add
           </button>
+          {talkaroundEngagedCount > 0 && (
+            <button
+              onClick={() => setClearTalkaroundOpen(true)}
+              className="px-2 py-1 text-xs text-cool-gray hover:text-neon-cyan border border-neon-cyan border-opacity-20 hover:border-opacity-50 rounded transition-colors focus:outline-none"
+              title="Clear the live talkaround-engaged state on every channel that has it set"
+            >
+              Clear Talkaround ({talkaroundEngagedCount})
+            </button>
+          )}
         </div>
       </div>
       <div className="mb-3 flex items-center gap-3 shrink-0">
@@ -202,6 +224,15 @@ export const ChannelsTab: React.FC = () => {
         message={`Delete ${pendingDeleteCount} selected ${formatPlural(pendingDeleteCount, 'channel')}?`}
         confirmLabel="Delete"
         variant="danger"
+      />
+      <ConfirmModal
+        isOpen={clearTalkaroundOpen}
+        onClose={() => setClearTalkaroundOpen(false)}
+        onConfirm={handleClearTalkaroundConfirm}
+        title="Clear Talkaround"
+        message={`Turn off the live talkaround-engaged state on ${talkaroundEngagedCount} ${formatPlural(talkaroundEngagedCount, 'channel')}?`}
+        confirmLabel="Clear"
+        variant="default"
       />
     </div>
   );

--- a/src/components/channels/ChannelsTab.tsx
+++ b/src/components/channels/ChannelsTab.tsx
@@ -6,6 +6,9 @@ import { useRadioCapabilities } from '../../hooks/useRadioCapabilities';
 import { ChannelsTable } from './ChannelsTable';
 import { createDefaultChannel } from '../../utils/channelHelpers';
 import { ConfirmModal } from '../ui/ConfirmModal';
+import { CsvExportImportButtons } from '../ui/CsvExportImportButtons';
+import { useAlert } from '../../hooks/useAlert';
+import { exportChannelsToCSV, importChannelsFromCSV, downloadCSV } from '../../services/csv';
 import type { Channel } from '../../models/Channel';
 
 const isVFOChannel = (n: number) => n === 4001 || n === 4002;
@@ -18,6 +21,8 @@ export const ChannelsTab: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [scrollToChannel, setScrollToChannel] = useState<number | null>(null);
   const [selectedChannelNumbers, setSelectedChannelNumbers] = useState<Set<number>>(new Set());
+  const { alertOpen, alertMessage, alertTitle, showAlert, closeAlert } = useAlert('Full CSV Export/Import');
+  const [pendingChannelsImport, setPendingChannelsImport] = useState<Channel[] | null>(null);
 
   const handleAddChannel = () => {
     // Find the next available channel number
@@ -80,6 +85,34 @@ export const ChannelsTab: React.FC = () => {
     setChannels(channels.map(ch => ch.unknown1A_3 ? { ...ch, unknown1A_3: false } : ch));
     setClearTalkaroundOpen(false);
   }, [channels, setChannels]);
+
+  // Full-fidelity CSV export/import (all channel modes and fields) — distinct from the
+  // Smart Import wizard's CHIRP export (analog-only) and Add-style merges: this round-trips
+  // the whole channel list and importing REPLACES it, matching an OEM-CPS-style backup/edit
+  // workflow rather than an additive import.
+  const handleExportChannelsCsv = useCallback(() => {
+    downloadCSV(exportChannelsToCSV(channels), 'channels.csv');
+  }, [channels]);
+
+  const handleImportChannelsFile = useCallback((file: File) => {
+    file.text().then(content => {
+      const result = importChannelsFromCSV(content);
+      if (!result.success || !result.channels) {
+        showAlert(result.errors?.join('\n') || 'Failed to import channels CSV', 'Import failed');
+        return;
+      }
+      setPendingChannelsImport(result.channels);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  }, [showAlert]);
+
+  const handleImportChannelsConfirm = useCallback(() => {
+    if (pendingChannelsImport) {
+      setChannels(pendingChannelsImport);
+    }
+    setPendingChannelsImport(null);
+  }, [pendingChannelsImport, setChannels]);
 
   // VFO A/B as channels 4001/4002 — DM-32 only; UV5R-Mini and other radios do not have these in the channel list
   const vfoChannels = useMemo(() => {
@@ -159,6 +192,12 @@ export const ChannelsTab: React.FC = () => {
               Clear Talkaround ({talkaroundEngagedCount})
             </button>
           )}
+          <CsvExportImportButtons
+            label="channels"
+            onExport={handleExportChannelsCsv}
+            onImportFile={handleImportChannelsFile}
+            exportDisabled={channels.length === 0}
+          />
         </div>
       </div>
       <div className="mb-3 flex items-center gap-3 shrink-0">
@@ -233,6 +272,23 @@ export const ChannelsTab: React.FC = () => {
         message={`Turn off the live talkaround-engaged state on ${talkaroundEngagedCount} ${formatPlural(talkaroundEngagedCount, 'channel')}?`}
         confirmLabel="Clear"
         variant="default"
+      />
+      <ConfirmModal
+        isOpen={pendingChannelsImport !== null}
+        onClose={() => setPendingChannelsImport(null)}
+        onConfirm={handleImportChannelsConfirm}
+        title="Import Channels CSV"
+        message={`Replace all ${channels.length} existing ${formatPlural(channels.length, 'channel')} with ${pendingChannelsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+        confirmLabel="Replace"
+        variant="danger"
+      />
+      <ConfirmModal
+        isOpen={alertOpen}
+        onClose={closeAlert}
+        title={alertTitle}
+        message={alertMessage}
+        confirmLabel="OK"
+        variant="alert"
       />
     </div>
   );

--- a/src/components/channels/ChannelsTable.tsx
+++ b/src/components/channels/ChannelsTable.tsx
@@ -254,7 +254,8 @@ export const ChannelsTable: React.FC<ChannelsTableProps> = ({
             <th className="px-2 py-2 text-left text-neon-cyan font-bold min-w-[75px]" title="Transmit tone (CTCSS/DCS)">TX Tone</th>
             <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[30px]" title="Lone Worker">LW</th>
             <th className="px-2 py-2 text-left text-neon-cyan font-bold min-w-[50px]" title="Scan list assignment">Scan List</th>
-            <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Free to Air">FTA</th>
+            <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Forbid Talkaround (CPS permission — not the live state)">FTA</th>
+            <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Talkaround engaged (live state) — not shown in OEM CPS either; can silently carry over from a channel's previous contents">TA</th>
             <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Emergency">Emerg</th>
             <th className="px-2 py-2 text-center text-neon-cyan font-bold min-w-[35px]" title="Emergency acknowledge">Emerg Ack</th>
             <th className="px-2 py-2 text-left text-neon-cyan font-bold min-w-[52px]" title="Emergency ID">Emerg ID</th>

--- a/src/components/contacts/ContactsTab.tsx
+++ b/src/components/contacts/ContactsTab.tsx
@@ -7,6 +7,10 @@ import { ContactsTable } from './ContactsTable';
 import { ProgressBar } from '../ui/ProgressBar';
 import { COUNTRIES_BY_REGION, type CountryRegion } from '../../constants/countries';
 import { US_STATES } from '../../constants/usStates';
+import { ConfirmModal } from '../ui/ConfirmModal';
+import { CsvExportImportButtons } from '../ui/CsvExportImportButtons';
+import { useAlert } from '../../hooks/useAlert';
+import { exportContactsToCSV, importContactsFromCSV, downloadCSV } from '../../services/csv';
 import type { Contact } from '../../models/Contact';
 
 // RadioID User interface
@@ -218,8 +222,36 @@ export const ContactsTab: React.FC = () => {
   const [truncationWarning, setTruncationWarning] = useState<string | null>(null);
   const [isReading, setIsReading] = useState(false);
   const [isWriting, setIsWriting] = useState(false);
-  
+  const { alertOpen, alertMessage, alertTitle, showAlert, closeAlert } = useAlert('Full CSV Export/Import');
+  const [pendingContactsImport, setPendingContactsImport] = useState<Contact[] | null>(null);
+
   const contactCapacity = radioInfo?.maxContacts ?? 50000;
+
+  // Full-fidelity CSV export/import (ID, DMR ID, call sign, city, province, country, remark) —
+  // distinct from the RadioID.net download above. Importing REPLACES all contacts.
+  const handleExportContactsCsv = useCallback(() => {
+    downloadCSV(exportContactsToCSV(contacts), 'contacts.csv');
+  }, [contacts]);
+
+  const handleImportContactsFile = useCallback((file: File) => {
+    file.text().then(content => {
+      const result = importContactsFromCSV(content);
+      if (!result.success || !result.contacts) {
+        showAlert(result.errors?.join('\n') || 'Failed to import contacts CSV', 'Import failed');
+        return;
+      }
+      setPendingContactsImport(result.contacts);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  }, [showAlert]);
+
+  const handleImportContactsConfirm = useCallback(() => {
+    if (pendingContactsImport) {
+      setContacts(pendingContactsImport);
+    }
+    setPendingContactsImport(null);
+  }, [pendingContactsImport, setContacts]);
 
   // Estimate time based on 150k contacts = 6 minutes
   const estimateTime = (contactCount: number): string => {
@@ -699,8 +731,16 @@ export const ContactsTab: React.FC = () => {
       <div className="flex-1 flex flex-col min-h-0">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-2xl font-bold text-neon-cyan">CSV Contacts</h2>
-          <div className="text-cool-gray">
-            {contacts.length} / {contactCapacity.toLocaleString()} {formatPlural(contacts.length, 'contact')}
+          <div className="flex items-center gap-4">
+            <div className="text-cool-gray">
+              {contacts.length} / {contactCapacity.toLocaleString()} {formatPlural(contacts.length, 'contact')}
+            </div>
+            <CsvExportImportButtons
+              label="contacts"
+              onExport={handleExportContactsCsv}
+              onImportFile={handleImportContactsFile}
+              exportDisabled={contacts.length === 0}
+            />
           </div>
         </div>
         <div className="mb-4 text-cool-gray text-sm">
@@ -710,6 +750,23 @@ export const ContactsTab: React.FC = () => {
           <ContactsTable />
         </div>
       </div>
+      <ConfirmModal
+        isOpen={pendingContactsImport !== null}
+        onClose={() => setPendingContactsImport(null)}
+        onConfirm={handleImportContactsConfirm}
+        title="Import Contacts CSV"
+        message={`Replace all ${contacts.length} existing ${formatPlural(contacts.length, 'contact')} with ${pendingContactsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+        confirmLabel="Replace"
+        variant="danger"
+      />
+      <ConfirmModal
+        isOpen={alertOpen}
+        onClose={closeAlert}
+        title={alertTitle}
+        message={alertMessage}
+        confirmLabel="OK"
+        variant="alert"
+      />
     </div>
   );
 };

--- a/src/components/digital/DigitalTab.tsx
+++ b/src/components/digital/DigitalTab.tsx
@@ -15,7 +15,12 @@ import { Card } from '../ui/Card';
 import { SectionTitle } from '../ui/SectionTitle';
 import { EmptyState } from '../ui/EmptyState';
 import { ConfirmModal } from '../ui/ConfirmModal';
+import { CsvExportImportButtons } from '../ui/CsvExportImportButtons';
+import { exportRXGroupsToCSV, importRXGroupsFromCSV, exportDMRRadioIDsToCSV, importDMRRadioIDsFromCSV, downloadCSV } from '../../services/csv';
+import type { RXGroup } from '../../models/RXGroup';
+import type { DMRRadioID } from '../../models/DMRRadioID';
 import { LIMITS } from '../../radios/dm32uv/constants';
+import { formatPlural } from '../../utils/formatPlural';
 
 const DEFAULT_TALK_GROUPS_MAX = 800;
 const DEFAULT_DMR_RADIO_IDS_MAX = 250;
@@ -28,9 +33,9 @@ export const DigitalTab: React.FC = () => {
   const dmrRadioIdsMax = limits?.DMR_RADIO_IDS_MAX ?? DEFAULT_DMR_RADIO_IDS_MAX;
   const { keys, keysLoaded, setKeys, updateKey } = useEncryptionKeysStore();
   const { systems: digitalEmergencies, setSystems: setDigitalEmergencies, setConfig: setDigitalEmergencyConfig, updateSystem, addSystem: addDigitalEmergency, deleteSystem: deleteDigitalEmergency } = useDigitalEmergencyStore();
-  const { radioIds, radioIdsLoaded, updateRadioId, addRadioId, deleteRadioId } = useDMRRadioIDsStore();
+  const { radioIds, radioIdsLoaded, updateRadioId, addRadioId, deleteRadioId, setRadioIds } = useDMRRadioIDsStore();
   const { contacts: quickContacts, contactsLoaded: quickContactsLoaded, updateContact, addContact, deleteContact, setMaxTalkGroups } = useQuickContactsStore();
-  const { groupsLoaded: rxGroupsLoaded } = useRXGroupsStore();
+  const { groups: rxGroups, groupsLoaded: rxGroupsLoaded, setGroups: setRXGroups } = useRXGroupsStore();
   const { messages, messagesLoaded, updateMessage, addMessage, deleteMessage } = useQuickMessagesStore();
   const { channels } = useChannelsStore();
 
@@ -128,6 +133,44 @@ export const DigitalTab: React.FC = () => {
     { type: 'contact'; index: number } | { type: 'message'; index: number } | { type: 'radioId'; index: number } | null
   >(null);
 
+  const [pendingRadioIdsImport, setPendingRadioIdsImport] = useState<DMRRadioID[] | null>(null);
+  const handleExportRadioIdsCsv = () => downloadCSV(exportDMRRadioIDsToCSV(radioIds), 'dmr_radio_ids.csv');
+  const handleImportRadioIdsFile = (file: File) => {
+    file.text().then(content => {
+      const result = importDMRRadioIDsFromCSV(content);
+      if (!result.success || !result.dmrRadioIds) {
+        showAlert(result.errors?.join('\n') || 'Failed to import DMR Radio IDs CSV', 'Import failed');
+        return;
+      }
+      setPendingRadioIdsImport(result.dmrRadioIds);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  };
+  const handleImportRadioIdsConfirm = () => {
+    if (pendingRadioIdsImport) setRadioIds(pendingRadioIdsImport);
+    setPendingRadioIdsImport(null);
+  };
+
+  const [pendingRXGroupsImport, setPendingRXGroupsImport] = useState<RXGroup[] | null>(null);
+  const handleExportRXGroupsCsv = () => downloadCSV(exportRXGroupsToCSV(rxGroups), 'rx_groups.csv');
+  const handleImportRXGroupsFile = (file: File) => {
+    file.text().then(content => {
+      const result = importRXGroupsFromCSV(content);
+      if (!result.success || !result.rxGroups) {
+        showAlert(result.errors?.join('\n') || 'Failed to import RX Groups CSV', 'Import failed');
+        return;
+      }
+      setPendingRXGroupsImport(result.rxGroups);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  };
+  const handleImportRXGroupsConfirm = () => {
+    if (pendingRXGroupsImport) setRXGroups(pendingRXGroupsImport);
+    setPendingRXGroupsImport(null);
+  };
+
   const handleDeleteContactClick = (index: number) => {
     setDeleteConfirm({ type: 'contact', index });
   };
@@ -213,14 +256,22 @@ export const DigitalTab: React.FC = () => {
               Manage DMR Radio IDs. Up to {dmrRadioIdsMax} IDs can be configured.
             </p>
           </div>
-          {radioIdsLoaded && radioIds.length < dmrRadioIdsMax && (
-            <button
-              onClick={handleAddRadioId}
-              className="px-3 py-1 bg-neon-cyan text-dark-charcoal rounded hover:bg-neon-cyan-bright transition-colors text-sm font-semibold"
-            >
-              + Add ID
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            {radioIdsLoaded && radioIds.length < dmrRadioIdsMax && (
+              <button
+                onClick={handleAddRadioId}
+                className="px-3 py-1 bg-neon-cyan text-dark-charcoal rounded hover:bg-neon-cyan-bright transition-colors text-sm font-semibold"
+              >
+                + Add ID
+              </button>
+            )}
+            <CsvExportImportButtons
+              label="DMR Radio IDs"
+              onExport={handleExportRadioIdsCsv}
+              onImportFile={handleImportRadioIdsFile}
+              exportDisabled={radioIds.length === 0}
+            />
+          </div>
         </div>
 
         {!radioIdsLoaded ? (
@@ -422,11 +473,19 @@ export const DigitalTab: React.FC = () => {
 
       {/* DMR RX Groups Section */}
       <div className="mb-8">
-        <div className="mb-4">
-          <SectionTitle as="h3" size="xl">DMR RX Groups</SectionTitle>
-          <p className="text-cool-gray text-sm">
-            Manage DMR RX Groups
-          </p>
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <SectionTitle as="h3" size="xl">DMR RX Groups</SectionTitle>
+            <p className="text-cool-gray text-sm">
+              Manage DMR RX Groups
+            </p>
+          </div>
+          <CsvExportImportButtons
+            label="RX Groups"
+            onExport={handleExportRXGroupsCsv}
+            onImportFile={handleImportRXGroupsFile}
+            exportDisabled={rxGroups.length === 0}
+          />
         </div>
 
         {!rxGroupsLoaded ? (
@@ -814,6 +873,24 @@ export const DigitalTab: React.FC = () => {
       message={alertMessage}
       confirmLabel="OK"
       variant="alert"
+    />
+    <ConfirmModal
+      isOpen={pendingRadioIdsImport !== null}
+      onClose={() => setPendingRadioIdsImport(null)}
+      onConfirm={handleImportRadioIdsConfirm}
+      title="Import DMR Radio IDs CSV"
+      message={`Replace all ${radioIds.length} existing DMR Radio ${formatPlural(radioIds.length, 'ID')} with ${pendingRadioIdsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+      confirmLabel="Replace"
+      variant="danger"
+    />
+    <ConfirmModal
+      isOpen={pendingRXGroupsImport !== null}
+      onClose={() => setPendingRXGroupsImport(null)}
+      onConfirm={handleImportRXGroupsConfirm}
+      title="Import RX Groups CSV"
+      message={`Replace all ${rxGroups.length} existing RX ${formatPlural(rxGroups.length, 'Group')} with ${pendingRXGroupsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+      confirmLabel="Replace"
+      variant="danger"
     />
     </>
   );

--- a/src/components/digital/DigitalTab.tsx
+++ b/src/components/digital/DigitalTab.tsx
@@ -16,7 +16,8 @@ import { SectionTitle } from '../ui/SectionTitle';
 import { EmptyState } from '../ui/EmptyState';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { CsvExportImportButtons } from '../ui/CsvExportImportButtons';
-import { exportRXGroupsToCSV, importRXGroupsFromCSV, exportDMRRadioIDsToCSV, importDMRRadioIDsFromCSV, downloadCSV } from '../../services/csv';
+import { exportRXGroupsToCSV, importRXGroupsFromCSV, exportDMRRadioIDsToCSV, importDMRRadioIDsFromCSV, exportQuickContactsToCSV, importQuickContactsFromCSV, downloadCSV } from '../../services/csv';
+import type { QuickContact } from '../../models/QuickContact';
 import type { RXGroup } from '../../models/RXGroup';
 import type { DMRRadioID } from '../../models/DMRRadioID';
 import { LIMITS } from '../../radios/dm32uv/constants';
@@ -34,7 +35,7 @@ export const DigitalTab: React.FC = () => {
   const { keys, keysLoaded, setKeys, updateKey } = useEncryptionKeysStore();
   const { systems: digitalEmergencies, setSystems: setDigitalEmergencies, setConfig: setDigitalEmergencyConfig, updateSystem, addSystem: addDigitalEmergency, deleteSystem: deleteDigitalEmergency } = useDigitalEmergencyStore();
   const { radioIds, radioIdsLoaded, updateRadioId, addRadioId, deleteRadioId, setRadioIds } = useDMRRadioIDsStore();
-  const { contacts: quickContacts, contactsLoaded: quickContactsLoaded, updateContact, addContact, deleteContact, setMaxTalkGroups } = useQuickContactsStore();
+  const { contacts: quickContacts, contactsLoaded: quickContactsLoaded, updateContact, addContact, deleteContact, setMaxTalkGroups, setContacts: setQuickContacts } = useQuickContactsStore();
   const { groups: rxGroups, groupsLoaded: rxGroupsLoaded, setGroups: setRXGroups } = useRXGroupsStore();
   const { messages, messagesLoaded, updateMessage, addMessage, deleteMessage } = useQuickMessagesStore();
   const { channels } = useChannelsStore();
@@ -169,6 +170,25 @@ export const DigitalTab: React.FC = () => {
   const handleImportRXGroupsConfirm = () => {
     if (pendingRXGroupsImport) setRXGroups(pendingRXGroupsImport);
     setPendingRXGroupsImport(null);
+  };
+
+  const [pendingTalkGroupsImport, setPendingTalkGroupsImport] = useState<QuickContact[] | null>(null);
+  const handleExportTalkGroupsCsv = () => downloadCSV(exportQuickContactsToCSV(quickContacts), 'talk_groups.csv');
+  const handleImportTalkGroupsFile = (file: File) => {
+    file.text().then(content => {
+      const result = importQuickContactsFromCSV(content);
+      if (!result.success || !result.quickContacts) {
+        showAlert(result.errors?.join('\n') || 'Failed to import Talk Groups CSV', 'Import failed');
+        return;
+      }
+      setPendingTalkGroupsImport(result.quickContacts);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  };
+  const handleImportTalkGroupsConfirm = () => {
+    if (pendingTalkGroupsImport) setQuickContacts(pendingTalkGroupsImport);
+    setPendingTalkGroupsImport(null);
   };
 
   const handleDeleteContactClick = (index: number) => {
@@ -374,20 +394,28 @@ export const DigitalTab: React.FC = () => {
               Manage DMR talk groups (contacts) for group calls, private calls, and all calls.
             </p>
           </div>
-          {quickContactsLoaded && (
-            <div className="flex items-center gap-3">
-              <div className="text-cool-gray text-sm">
-                {quickContacts.length}/{talkGroupsMax} talk groups
-              </div>
-              <button
-                onClick={handleAddContact}
-                disabled={quickContacts.length >= talkGroupsMax}
-                className="px-3 py-1 bg-neon-cyan text-dark-charcoal rounded hover:bg-neon-cyan-bright transition-colors text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                + Add Group
-              </button>
-            </div>
-          )}
+          <div className="flex items-center gap-3">
+            {quickContactsLoaded && (
+              <>
+                <div className="text-cool-gray text-sm">
+                  {quickContacts.length}/{talkGroupsMax} talk groups
+                </div>
+                <button
+                  onClick={handleAddContact}
+                  disabled={quickContacts.length >= talkGroupsMax}
+                  className="px-3 py-1 bg-neon-cyan text-dark-charcoal rounded hover:bg-neon-cyan-bright transition-colors text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  + Add Group
+                </button>
+              </>
+            )}
+            <CsvExportImportButtons
+              label="Talk Groups"
+              onExport={handleExportTalkGroupsCsv}
+              onImportFile={handleImportTalkGroupsFile}
+              exportDisabled={quickContacts.length === 0}
+            />
+          </div>
         </div>
 
         {!quickContactsLoaded ? (
@@ -889,6 +917,15 @@ export const DigitalTab: React.FC = () => {
       onConfirm={handleImportRXGroupsConfirm}
       title="Import RX Groups CSV"
       message={`Replace all ${rxGroups.length} existing RX ${formatPlural(rxGroups.length, 'Group')} with ${pendingRXGroupsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+      confirmLabel="Replace"
+      variant="danger"
+    />
+    <ConfirmModal
+      isOpen={pendingTalkGroupsImport !== null}
+      onClose={() => setPendingTalkGroupsImport(null)}
+      onConfirm={handleImportTalkGroupsConfirm}
+      title="Import Talk Groups CSV"
+      message={`Replace all ${quickContacts.length} existing talk ${formatPlural(quickContacts.length, 'group')} with ${pendingTalkGroupsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
       confirmLabel="Replace"
       variant="danger"
     />

--- a/src/components/import/sources/AirportSource.tsx
+++ b/src/components/import/sources/AirportSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber, selectionCardClass } from '../../../utils/importHelpers';
 import { generateAirportChannels, COMMON_AIRCRAFT_FREQUENCIES } from '../../../services/airportChannels';
 import { getAirportFrequenciesWithTypes, type AirportData } from '../../../data/airportsData';
@@ -22,8 +23,6 @@ export const AirportSource: React.FC<AirportSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [selectedAirports, setSelectedAirports] = useState<Set<number>>(new Set());
   const [airportZoneGrouping, setAirportZoneGrouping] = useState<'individual' | 'single'>('individual');
   const [includeCommonFrequencies, setIncludeCommonFrequencies] = useState(false);
@@ -79,7 +78,10 @@ export const AirportSource: React.FC<AirportSourceProps> = ({
         throw new Error('No airports selected');
       }
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Build the selected subset of common aircraft frequencies (if enabled)
       const commonFreqs = includeCommonFrequencies
@@ -99,13 +101,11 @@ export const AirportSource: React.FC<AirportSourceProps> = ({
         return;
       }
 
-      // Add channels
-      const updatedChannels = [...channels, ...result.channels];
-      setChannels(updatedChannels);
+      // Add channels — functional append, safe against concurrent add actions
+      useChannelsStore.getState().addChannels(result.channels);
 
       // Add zones (one per airport)
-      const updatedZones = [...zones, ...result.zones];
-      setZones(updatedZones);
+      useZonesStore.getState().addZones(result.zones);
 
       onGenerationResult({
         channels: result.channels.length,

--- a/src/components/import/sources/ChirpSource.tsx
+++ b/src/components/import/sources/ChirpSource.tsx
@@ -12,7 +12,7 @@ interface ChirpSourceProps {
 }
 
 export const ChirpSource: React.FC<ChirpSourceProps> = ({ onError }) => {
-  const { channels, setChannels } = useChannelsStore();
+  const { channels } = useChannelsStore();
 
   const [isImportingChirp, setIsImportingChirp] = useState(false);
   const [chirpImportResult, setChirpImportResult] = useState<{
@@ -33,14 +33,15 @@ export const ChirpSource: React.FC<ChirpSourceProps> = ({ onError }) => {
     try {
       const content = await file.text();
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const nextChannelNumber = getNextChannelNumber(useChannelsStore.getState().channels);
 
       const result = importChannelsFromChirpCSV(content, nextChannelNumber);
 
       if (result.success && result.channels) {
-        // Add imported channels
-        const newChannels = [...channels, ...result.channels];
-        setChannels(newChannels);
+        // Add imported channels — functional append, safe against concurrent add actions
+        useChannelsStore.getState().addChannels(result.channels);
 
         setChirpImportResult({
           operation: 'import',

--- a/src/components/import/sources/FixedChannelsSource.tsx
+++ b/src/components/import/sources/FixedChannelsSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
 import { getAvailableFixedChannelSets, getChannelsForSet } from '../../../services/fixedChannels';
 import { mergeChannelSetsWithExisting } from '../../../services/channelMerger';
@@ -20,8 +21,6 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [selectedFixedSets, setSelectedFixedSets] = useState<Set<string>>(new Set());
   const [isAddingFixed, setIsAddingFixed] = useState(false);
   const [expandedChannelSet, setExpandedChannelSet] = useState<string | null>(null);
@@ -38,7 +37,10 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
     onError('');
 
     try {
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Generate channels for each selected set. Each set gets a distinct
       // temporary number range — the merge mapping is keyed by these numbers,
@@ -61,7 +63,7 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
       // Merge overlaps within the new sets and dedupe against existing channels
       // (a new channel is reused only when ALL settings match an existing one).
       const { channelsToAdd, channelMapping } = mergeChannelSetsWithExisting(
-        channels,
+        currentChannels,
         channelSets,
         nextChannelNumber
       );
@@ -87,12 +89,11 @@ export const FixedChannelsSource: React.FC<FixedChannelsSourceProps> = ({
         }
       }
 
-      // Add only new channels (not duplicates)
-      const updatedChannels = [...channels, ...channelsToAdd];
-      setChannels(updatedChannels);
+      // Add only new channels (not duplicates) — functional append, safe against
+      // concurrent add actions
+      useChannelsStore.getState().addChannels(channelsToAdd);
 
-      const updatedZones = [...zones, ...newZones];
-      setZones(updatedZones);
+      useZonesStore.getState().addZones(newZones);
 
       onGenerationResult({
         channels: channelsToAdd.length,

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { useContactsStore } from '../../../store/contactsStore';
 import { useDMRRadioIDsStore } from '../../../store/dmrRadioIdsStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
@@ -20,8 +21,6 @@ interface MmdvmSourceProps {
 }
 
 export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationResult }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-  const { contacts, setContacts } = useContactsStore();
   const { radioIds } = useDMRRadioIDsStore();
 
   const [mmdvmFrequency, setMmdvmFrequency] = useState('431.150');
@@ -59,9 +58,13 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
     onError('');
 
     try {
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh reads at click time — see RptrsSource.tsx for why these can't be
+      // values captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const currentContacts = useContactsStore.getState().contacts;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
-      const maxContactId = contacts.length > 0 ? Math.max(...contacts.map((c) => c.id)) : 0;
+      const maxContactId = currentContacts.length > 0 ? Math.max(...currentContacts.map((c) => c.id)) : 0;
       const firstContactId = maxContactId + 1;
 
       const firstDmrRadioIdIndex =
@@ -84,9 +87,9 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         zoneName: mmdvmZoneName.trim() || undefined,
       });
 
-      setContacts([...contacts, ...result.contacts]);
-      setChannels([...channels, ...result.channels]);
-      setZones([...zones, result.zone]);
+      useContactsStore.getState().addContacts(result.contacts);
+      useChannelsStore.getState().addChannels(result.channels);
+      useZonesStore.getState().addZones([result.zone]);
 
       onGenerationResult({
         channels: result.channels.length,

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -7,8 +7,11 @@ import { getNextChannelNumber } from '../../../utils/importHelpers';
 import {
   generateMMDVMChannels,
   isValidMMDVMFrequency,
+  isValidMMDVMDuplexTxFrequency,
   MMDVM_FREQ_MIN_MHZ,
   MMDVM_FREQ_MAX_MHZ,
+  MMDVM_DUPLEX_TX_MIN_MHZ,
+  MMDVM_DUPLEX_TX_MAX_MHZ,
   type MMDVMChannelEntry,
 } from '../../../services/mmdvmChannels';
 import { Button } from '../../ui/Button';
@@ -24,6 +27,8 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
   const { radioIds } = useDMRRadioIDsStore();
 
   const [mmdvmFrequency, setMmdvmFrequency] = useState('431.150');
+  const [mmdvmDuplex, setMmdvmDuplex] = useState(false);
+  const [mmdvmTxFrequency, setMmdvmTxFrequency] = useState('');
   const [mmdvmEntries, setMmdvmEntries] = useState<MMDVMChannelEntry[]>([
     { channelName: '', talkGroupName: 'Local', talkGroupId: 9 },
   ]);
@@ -43,8 +48,16 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
   const handleAddMmdvmChannels = () => {
     const freq = parseFloat(mmdvmFrequency);
     if (!isValidMMDVMFrequency(freq)) {
-      onError(`Frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
+      onError(`RX frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
       return;
+    }
+    let txFreq: number | undefined;
+    if (mmdvmDuplex) {
+      txFreq = parseFloat(mmdvmTxFrequency);
+      if (!isValidMMDVMDuplexTxFrequency(txFreq)) {
+        onError(`TX frequency must be between ${MMDVM_DUPLEX_TX_MIN_MHZ} and ${MMDVM_DUPLEX_TX_MAX_MHZ} MHz`);
+        return;
+      }
     }
     const validEntries = mmdvmEntries.filter(
       (e) => (e.talkGroupName?.trim() || e.channelName?.trim()) && !isNaN(e.talkGroupId) && e.talkGroupId >= 0
@@ -80,6 +93,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
 
       const result = generateMMDVMChannels({
         frequencyMhz: freq,
+        txFrequencyMhz: txFreq,
         entries: validEntries,
         firstChannelNumber: nextChannelNumber,
         firstContactId,
@@ -106,7 +120,10 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
     <Card padding="tight" className="mb-4">
       <SectionTitle as="h3" size="lg" className="mb-2">MMDVM</SectionTitle>
       <p className="text-sm text-cool-gray mb-4">
-        Add simplex MMDVM hotspot channels (one frequency, Slot 2, Color Code 1). You can create multiple channels on the same frequency with different talk groups—for example, one for local (TG 9) and one for a brandmeister talk group.
+        Add MMDVM hotspot channels (Slot 2, Color Code 1). Simplex uses one frequency for RX and TX;
+        duplex pairs a separate TX frequency for a hotspot linked to a real repeater. You can create
+        multiple channels on the same frequency pair with different talk groups—for example, one for
+        local (TG 9) and one for a brandmeister talk group.
       </p>
 
       <div className="grid grid-cols-1 gap-4 mb-4">
@@ -123,7 +140,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
             />
           </div>
           <div>
-            <label className="block text-sm text-cool-gray mb-2">Frequency (MHz)</label>
+            <label className="block text-sm text-cool-gray mb-2">{mmdvmDuplex ? 'RX Frequency (MHz)' : 'Frequency (MHz)'}</label>
             <input
               type="number"
               value={mmdvmFrequency}
@@ -156,6 +173,36 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
               For TX on all channels
             </p>
           </div>
+        </div>
+
+        <div>
+          <label className="flex items-center gap-2 cursor-pointer w-fit">
+            <input
+              type="checkbox"
+              checked={mmdvmDuplex}
+              onChange={(e) => setMmdvmDuplex(e.target.checked)}
+              className="w-4 h-4 accent-neon-cyan"
+            />
+            <span className="text-sm text-cool-gray">Duplex (hotspot linked to a real repeater)</span>
+          </label>
+          {mmdvmDuplex && (
+            <div className="mt-2 max-w-xs">
+              <label className="block text-sm text-cool-gray mb-2">TX Frequency (MHz)</label>
+              <input
+                type="number"
+                value={mmdvmTxFrequency}
+                onChange={(e) => setMmdvmTxFrequency(e.target.value)}
+                min={MMDVM_DUPLEX_TX_MIN_MHZ}
+                max={MMDVM_DUPLEX_TX_MAX_MHZ}
+                step="0.001"
+                placeholder="e.g. 436.150"
+                className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
+              />
+              <p className="text-xs text-cool-gray mt-1">
+                {MMDVM_DUPLEX_TX_MIN_MHZ}–{MMDVM_DUPLEX_TX_MAX_MHZ} MHz — the repeater's input frequency
+              </p>
+            </div>
+          )}
         </div>
 
         <div>

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -7,11 +7,12 @@ import { getNextChannelNumber } from '../../../utils/importHelpers';
 import {
   generateMMDVMChannels,
   isValidMMDVMFrequency,
-  isValidMMDVMDuplexTxFrequency,
+  isValidMMDVMDuplexFrequency,
   MMDVM_FREQ_MIN_MHZ,
   MMDVM_FREQ_MAX_MHZ,
-  MMDVM_DUPLEX_TX_MIN_MHZ,
-  MMDVM_DUPLEX_TX_MAX_MHZ,
+  MMDVM_DUPLEX_VHF_MIN_MHZ,
+  MMDVM_DUPLEX_UHF_MAX_MHZ,
+  MMDVM_DUPLEX_RANGE_DESCRIPTION,
   type MMDVMChannelEntry,
 } from '../../../services/mmdvmChannels';
 import { Button } from '../../ui/Button';
@@ -48,17 +49,22 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
 
   const handleAddMmdvmChannels = () => {
     const freq = parseFloat(mmdvmFrequency);
-    if (!isValidMMDVMFrequency(freq)) {
-      onError(`RX frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
-      return;
-    }
     let txFreq: number | undefined;
     if (mmdvmDuplex) {
-      txFreq = parseFloat(mmdvmTxFrequency);
-      if (!isValidMMDVMDuplexTxFrequency(txFreq)) {
-        onError(`TX frequency must be between ${MMDVM_DUPLEX_TX_MIN_MHZ} and ${MMDVM_DUPLEX_TX_MAX_MHZ} MHz`);
+      // Duplex pairs with a real repeater — both sides use the broader 2m/70cm range, not
+      // the narrow simplex-hotspot calling range below.
+      if (!isValidMMDVMDuplexFrequency(freq)) {
+        onError(`RX frequency must be in ${MMDVM_DUPLEX_RANGE_DESCRIPTION}`);
         return;
       }
+      txFreq = parseFloat(mmdvmTxFrequency);
+      if (!isValidMMDVMDuplexFrequency(txFreq)) {
+        onError(`TX frequency must be in ${MMDVM_DUPLEX_RANGE_DESCRIPTION}`);
+        return;
+      }
+    } else if (!isValidMMDVMFrequency(freq)) {
+      onError(`Frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
+      return;
     }
     const validEntries = mmdvmEntries.filter(
       (e) => (e.talkGroupName?.trim() || e.channelName?.trim()) && !isNaN(e.talkGroupId) && e.talkGroupId >= 0
@@ -147,14 +153,16 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
               type="number"
               value={mmdvmFrequency}
               onChange={(e) => setMmdvmFrequency(e.target.value)}
-              min={MMDVM_FREQ_MIN_MHZ}
-              max={MMDVM_FREQ_MAX_MHZ}
+              min={mmdvmDuplex ? MMDVM_DUPLEX_VHF_MIN_MHZ : MMDVM_FREQ_MIN_MHZ}
+              max={mmdvmDuplex ? MMDVM_DUPLEX_UHF_MAX_MHZ : MMDVM_FREQ_MAX_MHZ}
               step="0.001"
               placeholder="431.150"
               className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
             />
             <p className="text-xs text-cool-gray mt-1">
-              {MMDVM_FREQ_MIN_MHZ}–{MMDVM_FREQ_MAX_MHZ} MHz
+              {mmdvmDuplex
+                ? `${MMDVM_DUPLEX_RANGE_DESCRIPTION} — the repeater's output frequency`
+                : `${MMDVM_FREQ_MIN_MHZ}–${MMDVM_FREQ_MAX_MHZ} MHz`}
             </p>
           </div>
           <div>
@@ -208,14 +216,14 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
                 type="number"
                 value={mmdvmTxFrequency}
                 onChange={(e) => setMmdvmTxFrequency(e.target.value)}
-                min={MMDVM_DUPLEX_TX_MIN_MHZ}
-                max={MMDVM_DUPLEX_TX_MAX_MHZ}
+                min={MMDVM_DUPLEX_VHF_MIN_MHZ}
+                max={MMDVM_DUPLEX_UHF_MAX_MHZ}
                 step="0.001"
                 placeholder="e.g. 436.150"
                 className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
               />
               <p className="text-xs text-cool-gray mt-1">
-                {MMDVM_DUPLEX_TX_MIN_MHZ}–{MMDVM_DUPLEX_TX_MAX_MHZ} MHz — the repeater's input frequency
+                {MMDVM_DUPLEX_RANGE_DESCRIPTION} — the repeater's input frequency
               </p>
             </div>
           )}

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { useChannelsStore } from '../../../store/channelsStore';
 import { useZonesStore } from '../../../store/zonesStore';
 import { useQuickContactsStore } from '../../../store/quickContactsStore';
@@ -16,6 +16,8 @@ import {
   MMDVM_DUPLEX_RANGE_DESCRIPTION,
   type MMDVMChannelEntry,
 } from '../../../services/mmdvmChannels';
+import { loadRptrsData, convertRptrFrequency, convertRptrOffset, type RptrData } from '../../../data/rptrsData';
+import { fetchBrandmeisterStaticTalkgroups, fetchBrandmeisterTalkgroupName } from '../../../services/brandmeisterApi';
 import type { QuickContact } from '../../../models/QuickContact';
 import { Button } from '../../ui/Button';
 import { Card } from '../../ui/Card';
@@ -33,6 +35,10 @@ interface MmdvmUiEntry {
   existingIndex: string; // '' = none selected, else String(QuickContact.index)
   newTalkGroupName: string;
   newTalkGroupId: number;
+  /** Per-entry timeslot override; '' = use the top-level Timeslot setting. A repeater's
+   *  static talk groups commonly split across both slots, which a single hotspot-wide
+   *  timeslot can't represent. */
+  timeslot: '' | '1' | '2';
 }
 
 const emptyEntry = (): MmdvmUiEntry => ({
@@ -41,6 +47,7 @@ const emptyEntry = (): MmdvmUiEntry => ({
   existingIndex: '',
   newTalkGroupName: '',
   newTalkGroupId: 9,
+  timeslot: '',
 });
 
 const isEntryFilled = (e: MmdvmUiEntry): boolean =>
@@ -55,8 +62,9 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
   const [mmdvmDuplex, setMmdvmDuplex] = useState(false);
   const [mmdvmTxFrequency, setMmdvmTxFrequency] = useState('');
   const [mmdvmTimeslot, setMmdvmTimeslot] = useState<'1' | '2'>('2');
+  const [mmdvmColorCode, setMmdvmColorCode] = useState('1');
   const [mmdvmEntries, setMmdvmEntries] = useState<MmdvmUiEntry[]>([
-    { channelName: '', useExisting: false, existingIndex: '', newTalkGroupName: 'Local', newTalkGroupId: 9 },
+    { channelName: '', useExisting: false, existingIndex: '', newTalkGroupName: 'Local', newTalkGroupId: 9, timeslot: '' },
   ]);
   const [mmdvmZoneName, setMmdvmZoneName] = useState('MMDVM');
   const [mmdvmUseExistingZone, setMmdvmUseExistingZone] = useState(false);
@@ -64,6 +72,86 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
   const [mmdvmDmrRadioIdIndex, setMmdvmDmrRadioIdIndex] = useState<string>(''); // '' = None, or String(index)
   const [isAddingMmdvm, setIsAddingMmdvm] = useState(false);
   const mmdvmDmrIdDefaultSetRef = useRef(false);
+
+  // Repeater lookup — prefills RX/TX/color code from the bundled repeater database, and
+  // (for BrandMeister-network repeaters) can pull in the repeater's static talk groups.
+  const [rptrs, setRptrs] = useState<RptrData[]>([]);
+  const [rptrSearch, setRptrSearch] = useState('');
+  const [selectedRptr, setSelectedRptr] = useState<RptrData | null>(null);
+  const [isImportingStaticTgs, setIsImportingStaticTgs] = useState(false);
+
+  useEffect(() => {
+    loadRptrsData().then(setRptrs).catch(() => { /* Repeater lookup is a convenience; silently unavailable if the dataset fails to load */ });
+  }, []);
+
+  const rptrMatches = useMemo(() => {
+    const q = rptrSearch.trim().toLowerCase();
+    if (q.length < 2) return [];
+    return rptrs
+      .filter((r) => r.status === 'ACTIVE' && (
+        r.callsign.toLowerCase().includes(q) ||
+        r.city.toLowerCase().includes(q) ||
+        r.state.toLowerCase().includes(q)
+      ))
+      .slice(0, 25);
+  }, [rptrs, rptrSearch]);
+
+  const handleSelectRptr = (rptr: RptrData) => {
+    const rx = convertRptrFrequency(rptr.frequency);
+    const tx = rx + convertRptrOffset(rptr.offset);
+    setSelectedRptr(rptr);
+    setRptrSearch(`${rptr.callsign} — ${rptr.city}, ${rptr.state}`);
+    setMmdvmDuplex(true);
+    setMmdvmFrequency(rx.toFixed(4));
+    setMmdvmTxFrequency(tx.toFixed(4));
+    setMmdvmColorCode(String(rptr.color_code));
+    if (!mmdvmZoneName.trim() || mmdvmZoneName === 'MMDVM') {
+      setMmdvmZoneName(rptr.callsign.substring(0, 16));
+    }
+  };
+
+  const handleImportStaticTalkgroups = async () => {
+    if (!selectedRptr) return;
+    setIsImportingStaticTgs(true);
+    onError('');
+    try {
+      const staticTgs = await fetchBrandmeisterStaticTalkgroups(selectedRptr.id);
+      if (staticTgs.length === 0) {
+        onError(`${selectedRptr.callsign} has no static talk groups configured on BrandMeister.`);
+        return;
+      }
+      const currentTalkGroups = useQuickContactsStore.getState().contacts;
+      const newEntries: MmdvmUiEntry[] = await Promise.all(staticTgs.map(async (tg) => {
+        // Match by numeric contact number, not name — an existing entry's name may have
+        // been shortened to fit the radio's 16-character limit.
+        const existing = currentTalkGroups.find((c) => c.contactNumber === tg.talkgroup);
+        if (existing) {
+          return {
+            channelName: existing.name,
+            useExisting: true,
+            existingIndex: String(existing.index),
+            newTalkGroupName: '',
+            newTalkGroupId: tg.talkgroup,
+            timeslot: String(tg.slot) as '1' | '2',
+          };
+        }
+        const name = (await fetchBrandmeisterTalkgroupName(tg.talkgroup)) || `TG ${tg.talkgroup}`;
+        return {
+          channelName: name,
+          useExisting: false,
+          existingIndex: '',
+          newTalkGroupName: name,
+          newTalkGroupId: tg.talkgroup,
+          timeslot: String(tg.slot) as '1' | '2',
+        };
+      }));
+      setMmdvmEntries(newEntries);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to fetch static talk groups from BrandMeister');
+    } finally {
+      setIsImportingStaticTgs(false);
+    }
+  };
 
   // Preset MMDVM DMR Radio ID to first ID (slot 1) when list becomes available, once
   useEffect(() => {
@@ -142,8 +230,9 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
       let nextTalkGroupIndex = currentTalkGroups.length + 1;
       const newTalkGroups: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[] = [];
       const resolvedEntries: MMDVMChannelEntry[] = filledEntries.map((entry) => {
+        const entryTimeslot = entry.timeslot === '' ? undefined : (entry.timeslot === '1' ? 1 : 2);
         if (entry.useExisting) {
-          return { channelName: entry.channelName, contactId: parseInt(entry.existingIndex, 10) };
+          return { channelName: entry.channelName, contactId: parseInt(entry.existingIndex, 10), timeslot: entryTimeslot };
         }
         const contactId = nextTalkGroupIndex++;
         newTalkGroups.push({
@@ -152,7 +241,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
           callType: 0x04, // Group Call
           flag: 0, // PC-created
         });
-        return { channelName: entry.channelName, contactId };
+        return { channelName: entry.channelName, contactId, timeslot: entryTimeslot };
       });
 
       const result = generateMMDVMChannels({
@@ -162,6 +251,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         firstChannelNumber: nextChannelNumber,
         dmrRadioIdIndex: validDmrIndex,
         timeslot: mmdvmTimeslot === '1' ? 1 : 2,
+        colorCode: parseInt(mmdvmColorCode, 10) || 1,
       });
 
       if (newTalkGroups.length > 0) {
@@ -197,16 +287,70 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
 
   return (
     <Card padding="tight" className="mb-4">
-      <SectionTitle as="h3" size="lg" className="mb-2">MMDVM</SectionTitle>
+      <SectionTitle as="h3" size="lg" className="mb-2">MMDVM / Repeater</SectionTitle>
       <p className="text-sm text-cool-gray mb-4">
-        Add MMDVM hotspot channels (Color Code 1). Simplex uses one frequency for RX and TX; duplex
-        pairs a separate TX frequency for a hotspot linked to a real repeater. You can create multiple
-        channels on the same frequency pair with different talk groups—for example, one for local
-        (TG 9) and one for a brandmeister talk group.
+        Add digital channels for an MMDVM hotspot or a real DMR repeater. Simplex uses one frequency
+        for RX and TX; duplex pairs a separate TX frequency for a hotspot or repeater. You can create
+        multiple channels on the same frequency pair with different talk groups—for example, one for
+        local (TG 9) and one for a brandmeister talk group.
       </p>
 
+      <div className="mb-4">
+        <label className="block text-sm text-cool-gray mb-2">Look up a repeater (optional)</label>
+        <input
+          type="text"
+          value={rptrSearch}
+          onChange={(e) => {
+            setRptrSearch(e.target.value);
+            setSelectedRptr(null);
+          }}
+          placeholder="Search by callsign, city, or state..."
+          className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
+        />
+        {rptrMatches.length > 0 && !selectedRptr && (
+          <div className="mt-1 max-h-48 overflow-y-auto border border-neon-cyan border-opacity-30 rounded bg-black">
+            {rptrMatches.map((r) => (
+              <div
+                key={r.id}
+                onClick={() => handleSelectRptr(r)}
+                className="px-3 py-2 text-sm text-cool-gray hover:bg-neon-cyan hover:bg-opacity-10 hover:text-white cursor-pointer border-b border-neon-cyan border-opacity-10 last:border-0"
+              >
+                <span className="text-neon-cyan font-semibold">{r.callsign}</span> — {r.city}, {r.state}
+                {' · '}{convertRptrFrequency(r.frequency).toFixed(4)} MHz · CC{r.color_code} · {r.ipsc_network || 'Unknown network'}
+              </div>
+            ))}
+          </div>
+        )}
+        {selectedRptr && (
+          <div className="mt-2 flex items-center justify-between gap-2 p-2 rounded border border-neon-cyan border-opacity-30 bg-black bg-opacity-30">
+            <span className="text-sm text-cool-gray">
+              Prefilled RX/TX/color code from <span className="text-neon-cyan">{selectedRptr.callsign}</span>
+              {selectedRptr.ipsc_network?.toLowerCase() === 'brandmeister' ? ' (BrandMeister)' : ''}
+            </span>
+            <div className="flex items-center gap-2">
+              {selectedRptr.ipsc_network?.toLowerCase() === 'brandmeister' && (
+                <Button
+                  onClick={handleImportStaticTalkgroups}
+                  disabled={isImportingStaticTgs}
+                  className="bg-neon-cyan text-dark-charcoal hover:bg-neon-cyan-bright text-xs px-2 py-1"
+                >
+                  {isImportingStaticTgs ? 'Importing...' : 'Import static TGs'}
+                </Button>
+              )}
+              <button
+                type="button"
+                onClick={() => { setSelectedRptr(null); setRptrSearch(''); }}
+                className="text-sm text-cool-gray hover:text-white"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
       <div className="grid grid-cols-1 gap-4 mb-4">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 items-start">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 items-start">
           <div>
             <label className="flex items-center gap-2 cursor-pointer w-fit mb-2">
               <input
@@ -291,6 +435,20 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
               Match your hotspot/repeater's slot
             </p>
           </div>
+          <div>
+            <label className="block text-sm text-cool-gray mb-2">Color Code</label>
+            <input
+              type="number"
+              value={mmdvmColorCode}
+              onChange={(e) => setMmdvmColorCode(e.target.value)}
+              min={0}
+              max={15}
+              className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
+            />
+            <p className="text-xs text-cool-gray mt-1">
+              0–15 (hotspots are usually 1)
+            </p>
+          </div>
         </div>
 
         <div>
@@ -350,7 +508,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
                       className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
                     />
                   </div>
-                  <div className="col-span-5">
+                  <div className="col-span-3">
                     <label className="flex items-center gap-2 cursor-pointer">
                       <input
                         type="checkbox"
@@ -364,6 +522,22 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
                       />
                       <span className="text-xs text-cool-gray">Use existing talk group</span>
                     </label>
+                  </div>
+                  <div className="col-span-2">
+                    <label className="block text-xs text-cool-gray mb-1">Slot</label>
+                    <select
+                      value={entry.timeslot}
+                      onChange={(e) => {
+                        const next = [...mmdvmEntries];
+                        next[index] = { ...next[index], timeslot: e.target.value as '' | '1' | '2' };
+                        setMmdvmEntries(next);
+                      }}
+                      className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
+                    >
+                      <option value="">Default</option>
+                      <option value="1">TS1</option>
+                      <option value="2">TS2</option>
+                    </select>
                   </div>
                   <div className="col-span-3 flex items-end gap-1 justify-end">
                     {mmdvmEntries.length > 1 ? (
@@ -457,8 +631,8 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         )}
 
         <p className="text-xs text-cool-gray">
-          Settings: Digital, Color Code 1. Selected DMR Radio ID is used for TX on all channels. New talk
-          groups are added to the Talk Groups list in the Digital tab.
+          Settings: Digital. Selected DMR Radio ID is used for TX on all channels. New talk groups are
+          added to the Talk Groups list in the Digital tab.
         </p>
       </div>
 

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -29,6 +29,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
   const [mmdvmFrequency, setMmdvmFrequency] = useState('431.150');
   const [mmdvmDuplex, setMmdvmDuplex] = useState(false);
   const [mmdvmTxFrequency, setMmdvmTxFrequency] = useState('');
+  const [mmdvmTimeslot, setMmdvmTimeslot] = useState<'1' | '2'>('2');
   const [mmdvmEntries, setMmdvmEntries] = useState<MMDVMChannelEntry[]>([
     { channelName: '', talkGroupName: 'Local', talkGroupId: 9 },
   ]);
@@ -99,6 +100,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         firstContactId,
         dmrRadioIdIndex: validDmrIndex,
         zoneName: mmdvmZoneName.trim() || undefined,
+        timeslot: mmdvmTimeslot === '1' ? 1 : 2,
       });
 
       useContactsStore.getState().addContacts(result.contacts);
@@ -120,14 +122,14 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
     <Card padding="tight" className="mb-4">
       <SectionTitle as="h3" size="lg" className="mb-2">MMDVM</SectionTitle>
       <p className="text-sm text-cool-gray mb-4">
-        Add MMDVM hotspot channels (Slot 2, Color Code 1). Simplex uses one frequency for RX and TX;
-        duplex pairs a separate TX frequency for a hotspot linked to a real repeater. You can create
-        multiple channels on the same frequency pair with different talk groups—for example, one for
-        local (TG 9) and one for a brandmeister talk group.
+        Add MMDVM hotspot channels (Color Code 1). Simplex uses one frequency for RX and TX; duplex
+        pairs a separate TX frequency for a hotspot linked to a real repeater. You can create multiple
+        channels on the same frequency pair with different talk groups—for example, one for local
+        (TG 9) and one for a brandmeister talk group.
       </p>
 
       <div className="grid grid-cols-1 gap-4 mb-4">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <div>
             <label className="block text-sm text-cool-gray mb-2">Zone name</label>
             <input
@@ -171,6 +173,20 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
             </select>
             <p className="text-xs text-cool-gray mt-1">
               For TX on all channels
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm text-cool-gray mb-2">Timeslot</label>
+            <select
+              value={mmdvmTimeslot}
+              onChange={(e) => setMmdvmTimeslot(e.target.value === '1' ? '1' : '2')}
+              className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
+            >
+              <option value="1">TS1</option>
+              <option value="2">TS2</option>
+            </select>
+            <p className="text-xs text-cool-gray mt-1">
+              Match your hotspot/repeater's slot
             </p>
           </div>
         </div>
@@ -300,7 +316,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         )}
 
         <p className="text-xs text-cool-gray">
-          Settings: Digital, Slot 2, Color Code 1. Selected DMR Radio ID is used for TX on all channels.
+          Settings: Digital, Color Code 1. Selected DMR Radio ID is used for TX on all channels.
         </p>
       </div>
 

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -337,6 +337,12 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
                   {isImportingStaticTgs ? 'Importing...' : 'Import static TGs'}
                 </Button>
               )}
+              <Button
+                onClick={() => setMmdvmEntries([...mmdvmEntries, { ...emptyEntry(), useExisting: talkGroups.length > 0 }])}
+                className="bg-transparent border border-neon-cyan text-neon-cyan hover:bg-neon-cyan hover:bg-opacity-10 text-xs px-2 py-1"
+              >
+                + Add talk group
+              </Button>
               <button
                 type="button"
                 onClick={() => { setSelectedRptr(null); setRptrSearch(''); }}

--- a/src/components/import/sources/MmdvmSource.tsx
+++ b/src/components/import/sources/MmdvmSource.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useChannelsStore } from '../../../store/channelsStore';
 import { useZonesStore } from '../../../store/zonesStore';
-import { useContactsStore } from '../../../store/contactsStore';
+import { useQuickContactsStore } from '../../../store/quickContactsStore';
 import { useDMRRadioIDsStore } from '../../../store/dmrRadioIdsStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
+import { generateZoneId } from '../../../utils/zoneHelpers';
 import {
   generateMMDVMChannels,
   isValidMMDVMFrequency,
@@ -15,6 +16,7 @@ import {
   MMDVM_DUPLEX_RANGE_DESCRIPTION,
   type MMDVMChannelEntry,
 } from '../../../services/mmdvmChannels';
+import type { QuickContact } from '../../../models/QuickContact';
 import { Button } from '../../ui/Button';
 import { Card } from '../../ui/Card';
 import { SectionTitle } from '../../ui/SectionTitle';
@@ -24,17 +26,41 @@ interface MmdvmSourceProps {
   onGenerationResult: (r: { channels: number; zones: number }) => void;
 }
 
+interface MmdvmUiEntry {
+  channelName: string;
+  /** true = reference an existing Talk Group (QuickContact); false = create a new one */
+  useExisting: boolean;
+  existingIndex: string; // '' = none selected, else String(QuickContact.index)
+  newTalkGroupName: string;
+  newTalkGroupId: number;
+}
+
+const emptyEntry = (): MmdvmUiEntry => ({
+  channelName: '',
+  useExisting: false,
+  existingIndex: '',
+  newTalkGroupName: '',
+  newTalkGroupId: 9,
+});
+
+const isEntryFilled = (e: MmdvmUiEntry): boolean =>
+  e.useExisting ? e.existingIndex !== '' : (e.newTalkGroupName.trim() !== '' || e.channelName.trim() !== '');
+
 export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationResult }) => {
   const { radioIds } = useDMRRadioIDsStore();
+  const { contacts: talkGroups } = useQuickContactsStore();
+  const { zones } = useZonesStore();
 
   const [mmdvmFrequency, setMmdvmFrequency] = useState('431.150');
   const [mmdvmDuplex, setMmdvmDuplex] = useState(false);
   const [mmdvmTxFrequency, setMmdvmTxFrequency] = useState('');
   const [mmdvmTimeslot, setMmdvmTimeslot] = useState<'1' | '2'>('2');
-  const [mmdvmEntries, setMmdvmEntries] = useState<MMDVMChannelEntry[]>([
-    { channelName: '', talkGroupName: 'Local', talkGroupId: 9 },
+  const [mmdvmEntries, setMmdvmEntries] = useState<MmdvmUiEntry[]>([
+    { channelName: '', useExisting: false, existingIndex: '', newTalkGroupName: 'Local', newTalkGroupId: 9 },
   ]);
   const [mmdvmZoneName, setMmdvmZoneName] = useState('MMDVM');
+  const [mmdvmUseExistingZone, setMmdvmUseExistingZone] = useState(false);
+  const [mmdvmExistingZoneId, setMmdvmExistingZoneId] = useState('');
   const [mmdvmDmrRadioIdIndex, setMmdvmDmrRadioIdIndex] = useState<string>(''); // '' = None, or String(index)
   const [isAddingMmdvm, setIsAddingMmdvm] = useState(false);
   const mmdvmDmrIdDefaultSetRef = useRef(false);
@@ -66,11 +92,25 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
       onError(`Frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
       return;
     }
-    const validEntries = mmdvmEntries.filter(
-      (e) => (e.talkGroupName?.trim() || e.channelName?.trim()) && !isNaN(e.talkGroupId) && e.talkGroupId >= 0
-    );
-    if (validEntries.length === 0) {
-      onError('Add at least one channel with a Talk Group name and Talk Group ID.');
+
+    const filledEntries = mmdvmEntries.filter(isEntryFilled);
+    if (filledEntries.length === 0) {
+      onError('Add at least one channel with a talk group (existing or new).');
+      return;
+    }
+    for (const entry of filledEntries) {
+      if (entry.useExisting) {
+        if (entry.existingIndex === '' || !talkGroups.some((tg) => tg.index === parseInt(entry.existingIndex, 10))) {
+          onError('Select a valid existing talk group for each channel using one, or switch it to "New".');
+          return;
+        }
+      } else if (!entry.newTalkGroupName.trim() || isNaN(entry.newTalkGroupId) || entry.newTalkGroupId < 0) {
+        onError('Enter a talk group name and ID for each new channel.');
+        return;
+      }
+    }
+    if (mmdvmUseExistingZone && !mmdvmExistingZoneId) {
+      onError('Select an existing zone, or uncheck "Add to existing zone" to create a new one.');
       return;
     }
 
@@ -81,11 +121,7 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
       // Fresh reads at click time — see RptrsSource.tsx for why these can't be
       // values captured at render time.
       const currentChannels = useChannelsStore.getState().channels;
-      const currentContacts = useContactsStore.getState().contacts;
       const nextChannelNumber = getNextChannelNumber(currentChannels);
-
-      const maxContactId = currentContacts.length > 0 ? Math.max(...currentContacts.map((c) => c.id)) : 0;
-      const firstContactId = maxContactId + 1;
 
       const firstDmrRadioIdIndex =
         mmdvmDmrRadioIdIndex === '' || mmdvmDmrRadioIdIndex === 'none'
@@ -98,20 +134,55 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
           ? firstDmrRadioIdIndex
           : undefined;
 
+      // Resolve talk groups: entries referencing an existing one use its index directly.
+      // New ones get sequential indices predicted here, then created atomically below in
+      // the same order — this stays in lockstep because nothing else touches the Talk
+      // Groups store between the read and the addContacts() call.
+      const currentTalkGroups = useQuickContactsStore.getState().contacts;
+      let nextTalkGroupIndex = currentTalkGroups.length + 1;
+      const newTalkGroups: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[] = [];
+      const resolvedEntries: MMDVMChannelEntry[] = filledEntries.map((entry) => {
+        if (entry.useExisting) {
+          return { channelName: entry.channelName, contactId: parseInt(entry.existingIndex, 10) };
+        }
+        const contactId = nextTalkGroupIndex++;
+        newTalkGroups.push({
+          name: (entry.newTalkGroupName || `TG ${entry.newTalkGroupId}`).substring(0, 16),
+          contactNumber: entry.newTalkGroupId,
+          callType: 0x04, // Group Call
+          flag: 0, // PC-created
+        });
+        return { channelName: entry.channelName, contactId };
+      });
+
       const result = generateMMDVMChannels({
         frequencyMhz: freq,
         txFrequencyMhz: txFreq,
-        entries: validEntries,
+        entries: resolvedEntries,
         firstChannelNumber: nextChannelNumber,
-        firstContactId,
         dmrRadioIdIndex: validDmrIndex,
-        zoneName: mmdvmZoneName.trim() || undefined,
         timeslot: mmdvmTimeslot === '1' ? 1 : 2,
       });
 
-      useContactsStore.getState().addContacts(result.contacts);
+      if (newTalkGroups.length > 0) {
+        useQuickContactsStore.getState().addContacts(newTalkGroups);
+      }
       useChannelsStore.getState().addChannels(result.channels);
-      useZonesStore.getState().addZones([result.zone]);
+
+      const newChannelNumbers = result.channels.map((c) => c.number);
+      if (mmdvmUseExistingZone && mmdvmExistingZoneId) {
+        const zone = useZonesStore.getState().zones.find((z) => z.id === mmdvmExistingZoneId);
+        if (zone) {
+          const merged = Array.from(new Set([...zone.channels, ...newChannelNumbers])).slice(0, 64);
+          useZonesStore.getState().updateZone(zone.id, { channels: merged });
+        }
+      } else {
+        useZonesStore.getState().addZones([{
+          id: generateZoneId(),
+          name: (mmdvmZoneName.trim() || 'MMDVM').substring(0, 16),
+          channels: newChannelNumbers,
+        }]);
+      }
 
       onGenerationResult({
         channels: result.channels.length,
@@ -135,17 +206,40 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
       </p>
 
       <div className="grid grid-cols-1 gap-4 mb-4">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 items-start">
           <div>
-            <label className="block text-sm text-cool-gray mb-2">Zone name</label>
-            <input
-              type="text"
-              value={mmdvmZoneName}
-              onChange={(e) => setMmdvmZoneName(e.target.value)}
-              placeholder="Default: MMDVM"
-              maxLength={16}
-              className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
-            />
+            <label className="flex items-center gap-2 cursor-pointer w-fit mb-2">
+              <input
+                type="checkbox"
+                checked={mmdvmUseExistingZone}
+                onChange={(e) => setMmdvmUseExistingZone(e.target.checked)}
+                className="w-4 h-4 accent-neon-cyan"
+              />
+              <span className="text-sm text-cool-gray">Add to existing zone</span>
+            </label>
+            {mmdvmUseExistingZone ? (
+              <select
+                value={mmdvmExistingZoneId}
+                onChange={(e) => setMmdvmExistingZoneId(e.target.value)}
+                className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
+              >
+                <option value="">Select a zone...</option>
+                {zones.map((zone) => (
+                  <option key={zone.id} value={zone.id}>
+                    {zone.name} ({zone.channels.length} channels)
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={mmdvmZoneName}
+                onChange={(e) => setMmdvmZoneName(e.target.value)}
+                placeholder="Default: MMDVM"
+                maxLength={16}
+                className="w-full bg-black border border-neon-cyan rounded px-3 py-2 text-white"
+              />
+            )}
           </div>
           <div>
             <label className="block text-sm text-cool-gray mb-2">{mmdvmDuplex ? 'RX Frequency (MHz)' : 'Frequency (MHz)'}</label>
@@ -230,88 +324,127 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         </div>
 
         <div>
-          <label className="block text-sm text-cool-gray mb-2">Channels (same frequency, different talk groups)</label>
+          <label className="block text-sm text-cool-gray mb-2">Channels</label>
           <p className="text-xs text-cool-gray mb-2">
-            Each row is one channel. Set the talk group name and ID (e.g. Local = 9, Brandmeister Canada = 3100).
+            Each row is one channel. Reference an existing talk group from the list, or create a new one.
           </p>
-          <div className="space-y-2 max-h-64 overflow-y-auto">
+          <div className="space-y-2 max-h-80 overflow-y-auto">
             {mmdvmEntries.map((entry, index) => (
               <div
                 key={index}
-                className="grid grid-cols-12 gap-2 items-end p-2 rounded border border-neon-cyan border-opacity-30 bg-black bg-opacity-30"
+                className="p-2 rounded border border-neon-cyan border-opacity-30 bg-black bg-opacity-30 space-y-2"
               >
-                <div className="col-span-3">
-                  <label className="block text-xs text-cool-gray mb-1">Channel name</label>
-                  <input
-                    type="text"
-                    value={entry.channelName}
-                    onChange={(e) => {
-                      const next = [...mmdvmEntries];
-                      next[index] = { ...next[index], channelName: e.target.value };
-                      setMmdvmEntries(next);
-                    }}
-                    placeholder="Optional"
-                    maxLength={16}
-                    className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
-                  />
+                <div className="grid grid-cols-12 gap-2 items-end">
+                  <div className="col-span-4">
+                    <label className="block text-xs text-cool-gray mb-1">Channel name</label>
+                    <input
+                      type="text"
+                      value={entry.channelName}
+                      onChange={(e) => {
+                        const next = [...mmdvmEntries];
+                        next[index] = { ...next[index], channelName: e.target.value };
+                        setMmdvmEntries(next);
+                      }}
+                      placeholder="Optional"
+                      maxLength={16}
+                      className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
+                    />
+                  </div>
+                  <div className="col-span-5">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={entry.useExisting}
+                        onChange={(e) => {
+                          const next = [...mmdvmEntries];
+                          next[index] = { ...next[index], useExisting: e.target.checked };
+                          setMmdvmEntries(next);
+                        }}
+                        className="w-4 h-4 accent-neon-cyan"
+                      />
+                      <span className="text-xs text-cool-gray">Use existing talk group</span>
+                    </label>
+                  </div>
+                  <div className="col-span-3 flex items-end gap-1 justify-end">
+                    {mmdvmEntries.length > 1 ? (
+                      <button
+                        type="button"
+                        onClick={() => setMmdvmEntries(mmdvmEntries.filter((_, i) => i !== index))}
+                        className="text-sm text-red-400 hover:text-red-300"
+                      >
+                        Remove
+                      </button>
+                    ) : null}
+                    {index === mmdvmEntries.length - 1 ? (
+                      <button
+                        type="button"
+                        onClick={() => setMmdvmEntries([...mmdvmEntries, emptyEntry()])}
+                        className="text-sm text-neon-cyan hover:text-neon-cyan-bright"
+                      >
+                        + Add channel
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
-                <div className="col-span-4">
-                  <label className="block text-xs text-cool-gray mb-1">Talk group name</label>
-                  <input
-                    type="text"
-                    value={entry.talkGroupName}
-                    onChange={(e) => {
-                      const next = [...mmdvmEntries];
-                      next[index] = { ...next[index], talkGroupName: e.target.value };
-                      setMmdvmEntries(next);
-                    }}
-                    placeholder="e.g. Local"
-                    maxLength={16}
-                    className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
-                  />
-                </div>
-                <div className="col-span-2">
-                  <label className="block text-xs text-cool-gray mb-1">TG ID</label>
-                  <input
-                    type="number"
-                    value={entry.talkGroupId || ''}
-                    onChange={(e) => {
-                      const v = e.target.value === '' ? 0 : parseInt(e.target.value, 10);
-                      const next = [...mmdvmEntries];
-                      next[index] = { ...next[index], talkGroupId: isNaN(v) ? 0 : v };
-                      setMmdvmEntries(next);
-                    }}
-                    min={0}
-                    max={16776415}
-                    placeholder="9"
-                    className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
-                  />
-                </div>
-                <div className="col-span-3 flex items-end gap-1">
-                  {mmdvmEntries.length > 1 ? (
-                    <button
-                      type="button"
-                      onClick={() => setMmdvmEntries(mmdvmEntries.filter((_, i) => i !== index))}
-                      className="text-sm text-red-400 hover:text-red-300"
+                {entry.useExisting ? (
+                  <div>
+                    <label className="block text-xs text-cool-gray mb-1">Talk group</label>
+                    <select
+                      value={entry.existingIndex}
+                      onChange={(e) => {
+                        const next = [...mmdvmEntries];
+                        next[index] = { ...next[index], existingIndex: e.target.value };
+                        setMmdvmEntries(next);
+                      }}
+                      className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
                     >
-                      Remove
-                    </button>
-                  ) : null}
-                  {index === mmdvmEntries.length - 1 ? (
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setMmdvmEntries([
-                          ...mmdvmEntries,
-                          { channelName: '', talkGroupName: '', talkGroupId: 9 },
-                        ])
-                      }
-                      className="text-sm text-neon-cyan hover:text-neon-cyan-bright"
-                    >
-                      + Add channel
-                    </button>
-                  ) : null}
-                </div>
+                      <option value="">Select a talk group...</option>
+                      {talkGroups.map((tg) => (
+                        <option key={tg.index} value={tg.index}>
+                          {tg.name} ({tg.contactNumber})
+                        </option>
+                      ))}
+                    </select>
+                    {talkGroups.length === 0 && (
+                      <p className="text-xs text-yellow-400 mt-1">No talk groups yet — uncheck to create one.</p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="block text-xs text-cool-gray mb-1">New talk group name</label>
+                      <input
+                        type="text"
+                        value={entry.newTalkGroupName}
+                        onChange={(e) => {
+                          const next = [...mmdvmEntries];
+                          next[index] = { ...next[index], newTalkGroupName: e.target.value };
+                          setMmdvmEntries(next);
+                        }}
+                        placeholder="e.g. Local"
+                        maxLength={16}
+                        className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-cool-gray mb-1">New TG ID</label>
+                      <input
+                        type="number"
+                        value={entry.newTalkGroupId || ''}
+                        onChange={(e) => {
+                          const v = e.target.value === '' ? 0 : parseInt(e.target.value, 10);
+                          const next = [...mmdvmEntries];
+                          next[index] = { ...next[index], newTalkGroupId: isNaN(v) ? 0 : v };
+                          setMmdvmEntries(next);
+                        }}
+                        min={0}
+                        max={16776415}
+                        placeholder="9"
+                        className="w-full bg-black border border-neon-cyan rounded px-2 py-1.5 text-white text-sm"
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -324,7 +457,8 @@ export const MmdvmSource: React.FC<MmdvmSourceProps> = ({ onError, onGenerationR
         )}
 
         <p className="text-xs text-cool-gray">
-          Settings: Digital, Color Code 1. Selected DMR Radio ID is used for TX on all channels.
+          Settings: Digital, Color Code 1. Selected DMR Radio ID is used for TX on all channels. New talk
+          groups are added to the Talk Groups list in the Digital tab.
         </p>
       </div>
 

--- a/src/components/import/sources/RptrsSource.tsx
+++ b/src/components/import/sources/RptrsSource.tsx
@@ -7,6 +7,7 @@ import { useZonesStore } from '../../../store/zonesStore';
 import { useQuickContactsStore } from '../../../store/quickContactsStore';
 import { getNextChannelNumber, selectionCardClass } from '../../../utils/importHelpers';
 import { generateZoneId } from '../../../utils/zoneHelpers';
+import { createDefaultChannel } from '../../../utils/channelHelpers';
 import { generateRptrsChannels } from '../../../services/rptrsChannels';
 import { generateMMDVMChannels, type MMDVMChannelEntry } from '../../../services/mmdvmChannels';
 import { fetchBrandmeisterStaticTalkgroups, fetchBrandmeisterTalkgroupName } from '../../../services/brandmeisterApi';
@@ -16,6 +17,7 @@ import {
   convertRptrOffset,
   groupRptrsByLocation,
   getStateAbbrev,
+  parseTimeslots,
   type RptrData,
 } from '../../../data/rptrsData';
 import { SelectAllButtons } from '../SelectAllButtons';
@@ -37,7 +39,7 @@ interface RptrStaticTgPreview {
   tgs: StaticTgPreviewEntry[];
 }
 
-const DEFAULT_STATIC_TG_NAME_FORMAT = '{call}-{tg}';
+const DEFAULT_STATIC_TG_NAME_FORMAT = '{call}-{city}';
 
 /**
  * Fill a channel-name template with per-channel tokens and truncate to the 16-char
@@ -82,6 +84,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   const [isLoadingStaticTgs, setIsLoadingStaticTgs] = useState(false);
   const [staticTgPreview, setStaticTgPreview] = useState<RptrStaticTgPreview[] | null>(null);
   const [staticTgSkipped, setStaticTgSkipped] = useState<string[]>([]);
+  const [staticTgFallbackRptrs, setStaticTgFallbackRptrs] = useState<RptrData[]>([]);
 
   const handleToggleRptr = (index: number) => {
     const newSelected = new Set(selectedRptrs);
@@ -92,24 +95,28 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
     }
     setSelectedRptrs(newSelected);
     setStaticTgPreview(null);
+    setStaticTgFallbackRptrs([]);
   };
 
   const handleSelectAllRptrs = () => {
     setSelectedRptrs(new Set(rptrs.map((_, i) => i)));
     setStaticTgPreview(null);
+    setStaticTgFallbackRptrs([]);
   };
 
   const handleDeselectAllRptrs = () => {
     setSelectedRptrs(new Set());
     setStaticTgPreview(null);
+    setStaticTgFallbackRptrs([]);
   };
 
   /**
    * Fetch static talk groups for the selected repeaters so the user can review and
    * uncheck ones they don't want before any channels are generated. BrandMeister only —
    * that's the only network in rptrs.json whose static TG assignments are queryable via
-   * a public API; other networks (or BrandMeister repeaters with none configured) are
-   * reported in staticTgSkipped instead of failing the whole batch.
+   * a public API. Repeaters that aren't on BrandMeister, fail the lookup, or have no
+   * static TGs configured aren't dropped — they fall back to the normal one-channel-
+   * per-timeslot behavior, same as when static-TG mode is off.
    */
   const handleLoadStaticTgs = async () => {
     setIsLoadingStaticTgs(true);
@@ -125,22 +132,26 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       }
 
       const preview: RptrStaticTgPreview[] = [];
-      const skipped: string[] = [];
+      const fallback: RptrData[] = [];
+      const notes: string[] = [];
 
       for (const rptr of uniqueRptrs.values()) {
         if ((rptr.ipsc_network || '').toLowerCase() !== 'brandmeister') {
-          skipped.push(`${rptr.callsign} (not BrandMeister)`);
+          notes.push(`${rptr.callsign} (not BrandMeister — normal channels)`);
+          fallback.push(rptr);
           continue;
         }
         let staticTgs;
         try {
           staticTgs = await fetchBrandmeisterStaticTalkgroups(rptr.id);
         } catch {
-          skipped.push(`${rptr.callsign} (lookup failed)`);
+          notes.push(`${rptr.callsign} (lookup failed — normal channels)`);
+          fallback.push(rptr);
           continue;
         }
         if (staticTgs.length === 0) {
-          skipped.push(`${rptr.callsign} (no static talk groups configured)`);
+          notes.push(`${rptr.callsign} (no static talk groups — normal channels)`);
+          fallback.push(rptr);
           continue;
         }
 
@@ -164,10 +175,8 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       }
 
       setStaticTgPreview(preview);
-      setStaticTgSkipped(skipped);
-      if (preview.length === 0) {
-        onError(`No static talk groups found.${skipped.length ? ' Skipped: ' + skipped.join(', ') : ''}`);
-      }
+      setStaticTgFallbackRptrs(fallback);
+      setStaticTgSkipped(notes);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to load static talk groups');
     } finally {
@@ -198,12 +207,15 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   };
 
   /**
-   * Build channels/zones/new-talk-groups from the reviewed preview (only checked TGs).
-   * Talk group resolution (existing vs. new) happens here, right before commit, against
-   * the freshest store state.
+   * Build channels/zones/new-talk-groups from the reviewed preview (only checked TGs),
+   * plus normal per-timeslot channels for repeaters that had no static TGs to review
+   * (fallbackRptrs — not on BrandMeister, lookup failed, or none configured). Talk group
+   * resolution (existing vs. new) happens here, right before commit, against the
+   * freshest store state.
    */
   const buildChannelsFromPreview = (
     preview: RptrStaticTgPreview[],
+    fallbackRptrs: RptrData[],
     startChannelNumber: number
   ): { channels: Channel[]; zones: Zone[]; newTalkGroups: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[] } => {
     const existingTalkGroups = useQuickContactsStore.getState().contacts;
@@ -212,13 +224,40 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
 
     const rptrsInPreview = preview.map(p => p.rptr);
     const locationGroups = rptrsZoneGrouping === 'location'
-      ? groupRptrsByLocation(rptrsInPreview, 2)
+      ? groupRptrsByLocation([...rptrsInPreview, ...fallbackRptrs], 2)
       : null;
 
     const channels: Channel[] = [];
     const zones: Zone[] = [];
     const allZoneChannels: number[] = [];
     let channelNumber = startChannelNumber;
+
+    const addChannelsToZone = (rptr: RptrData, rxFrequency: number, channelNumbers: number[]) => {
+      if (rptrsZoneGrouping === 'single') {
+        for (const num of channelNumbers) {
+          if (!allZoneChannels.includes(num)) allZoneChannels.push(num);
+        }
+      } else if (locationGroups) {
+        for (const [locationName, locationRptrs] of locationGroups.entries()) {
+          if (locationRptrs.some(r =>
+            r.callsign === rptr.callsign &&
+            Math.abs(convertRptrFrequency(r.frequency) - rxFrequency) < 0.001 &&
+            r.color_code === rptr.color_code
+          )) {
+            const zoneName = `DMR-${locationName}`.substring(0, 10);
+            let zone = zones.find(z => z.name === zoneName);
+            if (!zone) {
+              zone = { id: generateZoneId(), name: zoneName, channels: [] };
+              zones.push(zone);
+            }
+            for (const num of channelNumbers) {
+              if (!zone.channels.includes(num)) zone.channels.push(num);
+            }
+            break;
+          }
+        }
+      }
+    };
 
     for (const { rptr, rxFrequency, txFrequency, tgs } of preview) {
       const includedTgs = tgs.filter(tg => tg.include);
@@ -269,32 +308,47 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       }
       channelNumber += result.channels.length;
       channels.push(...result.channels);
-      const channelNumbers = result.channels.map(c => c.number);
+      addChannelsToZone(rptr, rxFrequency, result.channels.map(c => c.number));
+    }
 
-      if (rptrsZoneGrouping === 'single') {
-        for (const num of channelNumbers) {
-          if (!allZoneChannels.includes(num)) allZoneChannels.push(num);
+    // Repeaters with no static TGs to offer — same one-channel-per-timeslot behavior as
+    // static-TG mode being off, but sharing this function's zone grouping/numbering.
+    for (const rptr of fallbackRptrs) {
+      const rxFrequency = convertRptrFrequency(rptr.frequency);
+      const txFrequency = rxFrequency + convertRptrOffset(rptr.offset);
+      const timeslots = parseTimeslots(rptr.ts_linked);
+      const slotsToCreate = rptrsSeparateTimeslots ? timeslots : [timeslots[0] || 1];
+
+      const baseName = applyChannelNameFormat(rptrsChannelNameFormat, {
+        call: rptr.callsign,
+        city: rptr.city,
+        state: getStateAbbrev(rptr.state || ''),
+        tg: '',
+        tgname: '',
+      });
+
+      const channelNumbers: number[] = [];
+      for (const timeslot of slotsToCreate) {
+        let channelName = baseName;
+        if (rptrsSeparateTimeslots && timeslots.length > 1) {
+          channelName = `${baseName}-${timeslot}`.substring(0, 16);
         }
-      } else if (locationGroups) {
-        for (const [locationName, locationRptrs] of locationGroups.entries()) {
-          if (locationRptrs.some(r =>
-            r.callsign === rptr.callsign &&
-            Math.abs(convertRptrFrequency(r.frequency) - rxFrequency) < 0.001 &&
-            r.color_code === rptr.color_code
-          )) {
-            const zoneName = `DMR-${locationName}`.substring(0, 10);
-            let zone = zones.find(z => z.name === zoneName);
-            if (!zone) {
-              zone = { id: generateZoneId(), name: zoneName, channels: [] };
-              zones.push(zone);
-            }
-            for (const num of channelNumbers) {
-              if (!zone.channels.includes(num)) zone.channels.push(num);
-            }
-            break;
-          }
-        }
+        const channel = createDefaultChannel({
+          number: channelNumber++,
+          name: channelName,
+          rxFrequency,
+          txFrequency,
+          mode: 'Digital',
+          bandwidth: '12.5kHz',
+          power: 'High',
+          scanAdd: true,
+          colorCode: rptr.color_code,
+        });
+        channel.slotOperation = timeslot === 1 ? 0 : 1;
+        channels.push(channel);
+        channelNumbers.push(channel.number);
       }
+      addChannelsToZone(rptr, rxFrequency, channelNumbers);
     }
 
     if (rptrsZoneGrouping === 'single' && allZoneChannels.length > 0) {
@@ -339,7 +393,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       const result = rptrsUseStaticTgs && staticTgPreview
-        ? buildChannelsFromPreview(staticTgPreview, nextChannelNumber)
+        ? buildChannelsFromPreview(staticTgPreview, staticTgFallbackRptrs, nextChannelNumber)
         : generateRptrsChannels(
             nextChannelNumber,
             selectedRptrsList,
@@ -351,7 +405,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       if (result.channels.length === 0) {
         onError(
           rptrsUseStaticTgs
-            ? 'No static talk group channels generated — check at least one talk group'
+            ? 'No channels generated — check at least one talk group above'
             : 'No channels to add from selected DMR repeaters'
         );
         return;
@@ -397,6 +451,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       // Clear selection
       setSelectedRptrs(new Set());
       setStaticTgPreview(null);
+      setStaticTgFallbackRptrs([]);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to add DMR repeater channels');
     } finally {
@@ -533,19 +588,30 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"
+                  checked={rptrsSeparateTimeslots}
+                  onChange={(e) => setRptrsSeparateTimeslots(e.target.checked)}
+                />
+                <span className="text-cool-gray">Create separate channels for each timeslot (TS1, TS2)</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
                   checked={rptrsUseStaticTgs}
                   onChange={(e) => {
                     setRptrsUseStaticTgs(e.target.checked);
                     setStaticTgPreview(null);
+                    setStaticTgFallbackRptrs([]);
                   }}
                 />
                 <span className="text-cool-gray">Generate one channel per static talk group instead</span>
               </label>
-              {rptrsUseStaticTgs ? (
+              {rptrsUseStaticTgs && (
                 <>
                   <div className="text-xs text-cool-gray pl-6">
-                    Only works for BrandMeister repeaters — other networks will be skipped. Each
-                    channel's timeslot comes from the repeater's static talk group assignment.
+                    Only works for BrandMeister repeaters — repeaters on other networks (or with
+                    no static talk groups configured) fall back to normal channels per the
+                    timeslot option above. Each static-TG channel's timeslot comes from the
+                    repeater's own static talk group assignment.
                   </div>
 
                   <div className="pl-6 space-y-1">
@@ -576,7 +642,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
                     <>
                       {staticTgSkipped.length > 0 && (
                         <div className="text-xs text-cool-gray">
-                          Skipped: {staticTgSkipped.join(', ')}
+                          {staticTgSkipped.join(', ')}
                         </div>
                       )}
                       <div className="space-y-3 max-h-96 overflow-y-auto">
@@ -623,15 +689,6 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
                     </>
                   )}
                 </>
-              ) : (
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={rptrsSeparateTimeslots}
-                    onChange={(e) => setRptrsSeparateTimeslots(e.target.checked)}
-                  />
-                  <span className="text-cool-gray">Create separate channels for each timeslot (TS1, TS2)</span>
-                </label>
               )}
               {(!rptrsUseStaticTgs || staticTgPreview) && (
                 <Button
@@ -642,7 +699,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
                   {isAddingRptrs
                     ? 'Adding DMR Repeater Channels...'
                     : rptrsUseStaticTgs
-                      ? `Add Channels from Selected Talk Groups`
+                      ? 'Add DMR Repeater Channels'
                       : `Add ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'DMR Repeater Channel')}`}
                 </Button>
               )}

--- a/src/components/import/sources/RptrsSource.tsx
+++ b/src/components/import/sources/RptrsSource.tsx
@@ -22,6 +22,20 @@ import { Button } from '../../ui/Button';
 import { Card } from '../../ui/Card';
 import { SectionTitle } from '../../ui/SectionTitle';
 
+interface StaticTgPreviewEntry {
+  talkgroup: number;
+  slot: 1 | 2;
+  name: string;
+  include: boolean;
+}
+
+interface RptrStaticTgPreview {
+  rptr: RptrData;
+  rxFrequency: number;
+  txFrequency: number;
+  tgs: StaticTgPreviewEntry[];
+}
+
 interface RptrsSourceProps {
   rptrs: (RptrData & { distance?: number })[];
   isSearching: boolean;
@@ -45,6 +59,9 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   const [rptrsSeparateTimeslots, setRptrsSeparateTimeslots] = useState(true);
   const [rptrsUseStaticTgs, setRptrsUseStaticTgs] = useState(false);
   const [isAddingRptrs, setIsAddingRptrs] = useState(false);
+  const [isLoadingStaticTgs, setIsLoadingStaticTgs] = useState(false);
+  const [staticTgPreview, setStaticTgPreview] = useState<RptrStaticTgPreview[] | null>(null);
+  const [staticTgSkipped, setStaticTgSkipped] = useState<string[]>([]);
 
   const handleToggleRptr = (index: number) => {
     const newSelected = new Set(selectedRptrs);
@@ -54,40 +71,128 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       newSelected.add(index);
     }
     setSelectedRptrs(newSelected);
+    setStaticTgPreview(null);
   };
 
   const handleSelectAllRptrs = () => {
     setSelectedRptrs(new Set(rptrs.map((_, i) => i)));
+    setStaticTgPreview(null);
   };
 
   const handleDeselectAllRptrs = () => {
     setSelectedRptrs(new Set());
+    setStaticTgPreview(null);
   };
 
   /**
-   * Per-repeater, per-static-talk-group channel generation. BrandMeister only — that's the
-   * only network in rptrs.json whose static TG assignments are queryable via a public API.
-   * Repeaters on other networks (or BrandMeister repeaters with none configured) are skipped
-   * with a console warning rather than failing the whole batch.
+   * Fetch static talk groups for the selected repeaters so the user can review and
+   * uncheck ones they don't want before any channels are generated. BrandMeister only —
+   * that's the only network in rptrs.json whose static TG assignments are queryable via
+   * a public API; other networks (or BrandMeister repeaters with none configured) are
+   * reported in staticTgSkipped instead of failing the whole batch.
    */
-  const generateStaticTgChannels = async (
-    selectedRptrsList: (RptrData & { distance?: number })[],
+  const handleLoadStaticTgs = async () => {
+    setIsLoadingStaticTgs(true);
+    onError('');
+    try {
+      const selectedRptrsList = Array.from(selectedRptrs).map(i => rptrs[i]).filter(Boolean);
+      const rptrsToProcess = selectedRptrsList.map(({ distance: _distance, ...rptr }) => rptr);
+      const uniqueRptrs = new Map<string, RptrData>();
+      for (const rptr of rptrsToProcess) {
+        const freqMhz = convertRptrFrequency(rptr.frequency);
+        const key = `${rptr.callsign}|${freqMhz.toFixed(3)}|${rptr.color_code}`;
+        if (!uniqueRptrs.has(key)) uniqueRptrs.set(key, rptr);
+      }
+
+      const preview: RptrStaticTgPreview[] = [];
+      const skipped: string[] = [];
+
+      for (const rptr of uniqueRptrs.values()) {
+        if ((rptr.ipsc_network || '').toLowerCase() !== 'brandmeister') {
+          skipped.push(`${rptr.callsign} (not BrandMeister)`);
+          continue;
+        }
+        let staticTgs;
+        try {
+          staticTgs = await fetchBrandmeisterStaticTalkgroups(rptr.id);
+        } catch {
+          skipped.push(`${rptr.callsign} (lookup failed)`);
+          continue;
+        }
+        if (staticTgs.length === 0) {
+          skipped.push(`${rptr.callsign} (no static talk groups configured)`);
+          continue;
+        }
+
+        const tgs: StaticTgPreviewEntry[] = [];
+        for (const tg of staticTgs) {
+          const fetchedName = await fetchBrandmeisterTalkgroupName(tg.talkgroup);
+          tgs.push({
+            talkgroup: tg.talkgroup,
+            slot: tg.slot,
+            name: fetchedName || `TG ${tg.talkgroup}`,
+            include: true,
+          });
+        }
+
+        preview.push({
+          rptr,
+          rxFrequency: convertRptrFrequency(rptr.frequency),
+          txFrequency: convertRptrFrequency(rptr.frequency) + convertRptrOffset(rptr.offset),
+          tgs,
+        });
+      }
+
+      setStaticTgPreview(preview);
+      setStaticTgSkipped(skipped);
+      if (preview.length === 0) {
+        onError(`No static talk groups found.${skipped.length ? ' Skipped: ' + skipped.join(', ') : ''}`);
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to load static talk groups');
+    } finally {
+      setIsLoadingStaticTgs(false);
+    }
+  };
+
+  const handleToggleStaticTg = (rptrIndex: number, tgIndex: number) => {
+    setStaticTgPreview(prev => {
+      if (!prev) return prev;
+      const next = [...prev];
+      const entry = { ...next[rptrIndex] };
+      entry.tgs = entry.tgs.map((tg, i) => i === tgIndex ? { ...tg, include: !tg.include } : tg);
+      next[rptrIndex] = entry;
+      return next;
+    });
+  };
+
+  const handleToggleAllStaticTgsForRptr = (rptrIndex: number, include: boolean) => {
+    setStaticTgPreview(prev => {
+      if (!prev) return prev;
+      const next = [...prev];
+      const entry = { ...next[rptrIndex] };
+      entry.tgs = entry.tgs.map(tg => ({ ...tg, include }));
+      next[rptrIndex] = entry;
+      return next;
+    });
+  };
+
+  /**
+   * Build channels/zones/new-talk-groups from the reviewed preview (only checked TGs).
+   * Talk group resolution (existing vs. new) happens here, right before commit, against
+   * the freshest store state.
+   */
+  const buildChannelsFromPreview = (
+    preview: RptrStaticTgPreview[],
     startChannelNumber: number
-  ): Promise<{ channels: Channel[]; zones: Zone[]; newTalkGroups: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[] }> => {
+  ): { channels: Channel[]; zones: Zone[]; newTalkGroups: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[] } => {
     const existingTalkGroups = useQuickContactsStore.getState().contacts;
     const queuedNewTgs: { contactNumber: number; index: number; name: string; callType: number; flag: number }[] = [];
     let nextTgIndex = existingTalkGroups.length + 1;
 
-    const rptrsToProcess = selectedRptrsList.map(({ distance: _distance, ...rptr }) => rptr);
-    const uniqueRptrs = new Map<string, RptrData>();
-    for (const rptr of rptrsToProcess) {
-      const freqMhz = convertRptrFrequency(rptr.frequency);
-      const key = `${rptr.callsign}|${freqMhz.toFixed(3)}|${rptr.color_code}`;
-      if (!uniqueRptrs.has(key)) uniqueRptrs.set(key, rptr);
-    }
-
+    const rptrsInPreview = preview.map(p => p.rptr);
     const locationGroups = rptrsZoneGrouping === 'location'
-      ? groupRptrsByLocation(Array.from(uniqueRptrs.values()), 2)
+      ? groupRptrsByLocation(rptrsInPreview, 2)
       : null;
 
     const channels: Channel[] = [];
@@ -95,47 +200,32 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
     const allZoneChannels: number[] = [];
     let channelNumber = startChannelNumber;
 
-    for (const rptr of uniqueRptrs.values()) {
-      if ((rptr.ipsc_network || '').toLowerCase() !== 'brandmeister') {
-        console.warn(`Skipping static TG import for ${rptr.callsign} — not a BrandMeister repeater`);
-        continue;
-      }
+    for (const { rptr, rxFrequency, txFrequency, tgs } of preview) {
+      const includedTgs = tgs.filter(tg => tg.include);
+      if (includedTgs.length === 0) continue;
 
-      let staticTgs;
-      try {
-        staticTgs = await fetchBrandmeisterStaticTalkgroups(rptr.id);
-      } catch (err) {
-        console.warn(`Skipping static TG import for ${rptr.callsign} — lookup failed`, err);
-        continue;
-      }
-      if (staticTgs.length === 0) {
-        console.warn(`Skipping static TG import for ${rptr.callsign} — no static talk groups configured`);
-        continue;
-      }
-
-      const rxFrequency = convertRptrFrequency(rptr.frequency);
-      const txFrequency = rxFrequency + convertRptrOffset(rptr.offset);
-
-      const entries: MMDVMChannelEntry[] = [];
-      for (const tg of staticTgs) {
+      const entries: MMDVMChannelEntry[] = includedTgs.map(tg => {
         const existing = existingTalkGroups.find(c => c.contactNumber === tg.talkgroup)
           ?? queuedNewTgs.find(c => c.contactNumber === tg.talkgroup);
         let contactId: number;
         if (existing) {
           contactId = existing.index;
         } else {
-          const fetchedName = await fetchBrandmeisterTalkgroupName(tg.talkgroup);
-          const tgName = (fetchedName || `TG ${tg.talkgroup}`).substring(0, 16);
           contactId = nextTgIndex++;
-          queuedNewTgs.push({ contactNumber: tg.talkgroup, index: contactId, name: tgName, callType: 0x04, flag: 0x00 });
+          queuedNewTgs.push({
+            contactNumber: tg.talkgroup,
+            index: contactId,
+            name: tg.name.substring(0, 16),
+            callType: 0x04,
+            flag: 0x00,
+          });
         }
-        entries.push({
+        return {
           channelName: `${rptr.callsign}-${tg.talkgroup}`.substring(0, 16),
           contactId,
           timeslot: tg.slot,
-        });
-      }
-      if (entries.length === 0) continue;
+        };
+      });
 
       let result;
       try {
@@ -148,7 +238,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
           colorCode: rptr.color_code,
         });
       } catch (err) {
-        console.warn(`Skipping static TG import for ${rptr.callsign} — ${err instanceof Error ? err.message : 'invalid frequency'}`);
+        console.warn(`Skipping ${rptr.callsign} — ${err instanceof Error ? err.message : 'invalid frequency'}`);
         continue;
       }
       channelNumber += result.channels.length;
@@ -197,6 +287,10 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       onError('Please select at least one DMR repeater');
       return;
     }
+    if (rptrsUseStaticTgs && !staticTgPreview) {
+      onError('Load static talk groups first');
+      return;
+    }
 
     setIsAddingRptrs(true);
     onError('');
@@ -218,8 +312,8 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       const currentChannels = useChannelsStore.getState().channels;
       const nextChannelNumber = getNextChannelNumber(currentChannels);
 
-      const result = rptrsUseStaticTgs
-        ? await generateStaticTgChannels(selectedRptrsList, nextChannelNumber)
+      const result = rptrsUseStaticTgs && staticTgPreview
+        ? buildChannelsFromPreview(staticTgPreview, nextChannelNumber)
         : generateRptrsChannels(
             nextChannelNumber,
             selectedRptrsList,
@@ -231,7 +325,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       if (result.channels.length === 0) {
         onError(
           rptrsUseStaticTgs
-            ? 'No static talk group channels generated — selected repeaters may not be on BrandMeister, or have none configured'
+            ? 'No static talk group channels generated — check at least one talk group'
             : 'No channels to add from selected DMR repeaters'
         );
         return;
@@ -276,6 +370,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
 
       // Clear selection
       setSelectedRptrs(new Set());
+      setStaticTgPreview(null);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to add DMR repeater channels');
     } finally {
@@ -396,15 +491,79 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
                 <input
                   type="checkbox"
                   checked={rptrsUseStaticTgs}
-                  onChange={(e) => setRptrsUseStaticTgs(e.target.checked)}
+                  onChange={(e) => {
+                    setRptrsUseStaticTgs(e.target.checked);
+                    setStaticTgPreview(null);
+                  }}
                 />
                 <span className="text-cool-gray">Generate one channel per static talk group instead</span>
               </label>
               {rptrsUseStaticTgs ? (
-                <div className="text-xs text-cool-gray pl-6">
-                  Only works for BrandMeister repeaters — other networks will be skipped. Each
-                  channel's timeslot comes from the repeater's static talk group assignment.
-                </div>
+                <>
+                  <div className="text-xs text-cool-gray pl-6">
+                    Only works for BrandMeister repeaters — other networks will be skipped. Each
+                    channel's timeslot comes from the repeater's static talk group assignment.
+                  </div>
+
+                  {!staticTgPreview ? (
+                    <Button
+                      onClick={handleLoadStaticTgs}
+                      disabled={isLoadingStaticTgs}
+                      className="bg-neon-cyan text-black hover:bg-neon-cyan-bright w-full"
+                    >
+                      {isLoadingStaticTgs ? 'Loading Static Talk Groups...' : 'Load Static Talk Groups'}
+                    </Button>
+                  ) : (
+                    <>
+                      {staticTgSkipped.length > 0 && (
+                        <div className="text-xs text-cool-gray">
+                          Skipped: {staticTgSkipped.join(', ')}
+                        </div>
+                      )}
+                      <div className="space-y-3 max-h-96 overflow-y-auto">
+                        {staticTgPreview.map((entry, rptrIndex) => (
+                          <div key={`${entry.rptr.callsign}-${entry.rxFrequency}`} className="border border-neon-cyan/30 rounded p-2">
+                            <div className="flex items-center justify-between mb-1">
+                              <span className="font-semibold text-neon-cyan">
+                                {entry.rptr.callsign} — {entry.rxFrequency.toFixed(4)} MHz
+                              </span>
+                              <div className="flex gap-2 text-xs">
+                                <button
+                                  type="button"
+                                  className="text-neon-cyan hover:underline"
+                                  onClick={() => handleToggleAllStaticTgsForRptr(rptrIndex, true)}
+                                >
+                                  All
+                                </button>
+                                <button
+                                  type="button"
+                                  className="text-neon-cyan hover:underline"
+                                  onClick={() => handleToggleAllStaticTgsForRptr(rptrIndex, false)}
+                                >
+                                  None
+                                </button>
+                              </div>
+                            </div>
+                            <div className="space-y-1">
+                              {entry.tgs.map((tg, tgIndex) => (
+                                <label key={tg.talkgroup} className="flex items-center gap-2 cursor-pointer text-sm">
+                                  <input
+                                    type="checkbox"
+                                    checked={tg.include}
+                                    onChange={() => handleToggleStaticTg(rptrIndex, tgIndex)}
+                                  />
+                                  <span className="text-cool-gray">
+                                    TG {tg.talkgroup} — {tg.name} (TS{tg.slot})
+                                  </span>
+                                </label>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </>
               ) : (
                 <label className="flex items-center gap-2 cursor-pointer">
                   <input
@@ -415,17 +574,19 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
                   <span className="text-cool-gray">Create separate channels for each timeslot (TS1, TS2)</span>
                 </label>
               )}
-              <Button
-                onClick={handleAddRptrsChannels}
-                disabled={isAddingRptrs}
-                className="bg-neon-magenta text-white hover:bg-neon-magenta-bright w-full"
-              >
-                {isAddingRptrs
-                  ? 'Adding DMR Repeater Channels...'
-                  : rptrsUseStaticTgs
-                    ? `Add Channels from ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'Repeater')}'s Static Talk Groups`
-                    : `Add ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'DMR Repeater Channel')}`}
-              </Button>
+              {(!rptrsUseStaticTgs || staticTgPreview) && (
+                <Button
+                  onClick={handleAddRptrsChannels}
+                  disabled={isAddingRptrs}
+                  className="bg-neon-magenta text-white hover:bg-neon-magenta-bright w-full"
+                >
+                  {isAddingRptrs
+                    ? 'Adding DMR Repeater Channels...'
+                    : rptrsUseStaticTgs
+                      ? `Add Channels from Selected Talk Groups`
+                      : `Add ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'DMR Repeater Channel')}`}
+                </Button>
+              )}
             </div>
           )}
         </>

--- a/src/components/import/sources/RptrsSource.tsx
+++ b/src/components/import/sources/RptrsSource.tsx
@@ -1,11 +1,22 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
+import type { Channel, Zone } from '../../../models';
+import type { QuickContact } from '../../../models/QuickContact';
 import { useChannelsStore } from '../../../store/channelsStore';
 import { useZonesStore } from '../../../store/zonesStore';
+import { useQuickContactsStore } from '../../../store/quickContactsStore';
 import { getNextChannelNumber, selectionCardClass } from '../../../utils/importHelpers';
+import { generateZoneId } from '../../../utils/zoneHelpers';
 import { generateRptrsChannels } from '../../../services/rptrsChannels';
+import { generateMMDVMChannels, type MMDVMChannelEntry } from '../../../services/mmdvmChannels';
+import { fetchBrandmeisterStaticTalkgroups, fetchBrandmeisterTalkgroupName } from '../../../services/brandmeisterApi';
 import { mergeChannelSetsWithExisting } from '../../../services/channelMerger';
-import { convertRptrFrequency, type RptrData } from '../../../data/rptrsData';
+import {
+  convertRptrFrequency,
+  convertRptrOffset,
+  groupRptrsByLocation,
+  type RptrData,
+} from '../../../data/rptrsData';
 import { SelectAllButtons } from '../SelectAllButtons';
 import { Button } from '../../ui/Button';
 import { Card } from '../../ui/Card';
@@ -32,6 +43,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   const [selectedRptrs, setSelectedRptrs] = useState<Set<number>>(new Set());
   const [rptrsZoneGrouping, setRptrsZoneGrouping] = useState<'location' | 'single'>('location');
   const [rptrsSeparateTimeslots, setRptrsSeparateTimeslots] = useState(true);
+  const [rptrsUseStaticTgs, setRptrsUseStaticTgs] = useState(false);
   const [isAddingRptrs, setIsAddingRptrs] = useState(false);
 
   const handleToggleRptr = (index: number) => {
@@ -50,6 +62,134 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
 
   const handleDeselectAllRptrs = () => {
     setSelectedRptrs(new Set());
+  };
+
+  /**
+   * Per-repeater, per-static-talk-group channel generation. BrandMeister only — that's the
+   * only network in rptrs.json whose static TG assignments are queryable via a public API.
+   * Repeaters on other networks (or BrandMeister repeaters with none configured) are skipped
+   * with a console warning rather than failing the whole batch.
+   */
+  const generateStaticTgChannels = async (
+    selectedRptrsList: (RptrData & { distance?: number })[],
+    startChannelNumber: number
+  ): Promise<{ channels: Channel[]; zones: Zone[]; newTalkGroups: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[] }> => {
+    const existingTalkGroups = useQuickContactsStore.getState().contacts;
+    const queuedNewTgs: { contactNumber: number; index: number; name: string; callType: number; flag: number }[] = [];
+    let nextTgIndex = existingTalkGroups.length + 1;
+
+    const rptrsToProcess = selectedRptrsList.map(({ distance: _distance, ...rptr }) => rptr);
+    const uniqueRptrs = new Map<string, RptrData>();
+    for (const rptr of rptrsToProcess) {
+      const freqMhz = convertRptrFrequency(rptr.frequency);
+      const key = `${rptr.callsign}|${freqMhz.toFixed(3)}|${rptr.color_code}`;
+      if (!uniqueRptrs.has(key)) uniqueRptrs.set(key, rptr);
+    }
+
+    const locationGroups = rptrsZoneGrouping === 'location'
+      ? groupRptrsByLocation(Array.from(uniqueRptrs.values()), 2)
+      : null;
+
+    const channels: Channel[] = [];
+    const zones: Zone[] = [];
+    const allZoneChannels: number[] = [];
+    let channelNumber = startChannelNumber;
+
+    for (const rptr of uniqueRptrs.values()) {
+      if ((rptr.ipsc_network || '').toLowerCase() !== 'brandmeister') {
+        console.warn(`Skipping static TG import for ${rptr.callsign} — not a BrandMeister repeater`);
+        continue;
+      }
+
+      let staticTgs;
+      try {
+        staticTgs = await fetchBrandmeisterStaticTalkgroups(rptr.id);
+      } catch (err) {
+        console.warn(`Skipping static TG import for ${rptr.callsign} — lookup failed`, err);
+        continue;
+      }
+      if (staticTgs.length === 0) {
+        console.warn(`Skipping static TG import for ${rptr.callsign} — no static talk groups configured`);
+        continue;
+      }
+
+      const rxFrequency = convertRptrFrequency(rptr.frequency);
+      const txFrequency = rxFrequency + convertRptrOffset(rptr.offset);
+
+      const entries: MMDVMChannelEntry[] = [];
+      for (const tg of staticTgs) {
+        const existing = existingTalkGroups.find(c => c.contactNumber === tg.talkgroup)
+          ?? queuedNewTgs.find(c => c.contactNumber === tg.talkgroup);
+        let contactId: number;
+        if (existing) {
+          contactId = existing.index;
+        } else {
+          const fetchedName = await fetchBrandmeisterTalkgroupName(tg.talkgroup);
+          const tgName = (fetchedName || `TG ${tg.talkgroup}`).substring(0, 16);
+          contactId = nextTgIndex++;
+          queuedNewTgs.push({ contactNumber: tg.talkgroup, index: contactId, name: tgName, callType: 0x04, flag: 0x00 });
+        }
+        entries.push({
+          channelName: `${rptr.callsign}-${tg.talkgroup}`.substring(0, 16),
+          contactId,
+          timeslot: tg.slot,
+        });
+      }
+      if (entries.length === 0) continue;
+
+      let result;
+      try {
+        result = generateMMDVMChannels({
+          frequencyMhz: rxFrequency,
+          txFrequencyMhz: txFrequency,
+          entries,
+          firstChannelNumber: channelNumber,
+          dmrRadioIdIndex: undefined,
+          colorCode: rptr.color_code,
+        });
+      } catch (err) {
+        console.warn(`Skipping static TG import for ${rptr.callsign} — ${err instanceof Error ? err.message : 'invalid frequency'}`);
+        continue;
+      }
+      channelNumber += result.channels.length;
+      channels.push(...result.channels);
+      const channelNumbers = result.channels.map(c => c.number);
+
+      if (rptrsZoneGrouping === 'single') {
+        for (const num of channelNumbers) {
+          if (!allZoneChannels.includes(num)) allZoneChannels.push(num);
+        }
+      } else if (locationGroups) {
+        for (const [locationName, locationRptrs] of locationGroups.entries()) {
+          if (locationRptrs.some(r =>
+            r.callsign === rptr.callsign &&
+            Math.abs(convertRptrFrequency(r.frequency) - rxFrequency) < 0.001 &&
+            r.color_code === rptr.color_code
+          )) {
+            const zoneName = `DMR-${locationName}`.substring(0, 10);
+            let zone = zones.find(z => z.name === zoneName);
+            if (!zone) {
+              zone = { id: generateZoneId(), name: zoneName, channels: [] };
+              zones.push(zone);
+            }
+            for (const num of channelNumbers) {
+              if (!zone.channels.includes(num)) zone.channels.push(num);
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    if (rptrsZoneGrouping === 'single' && allZoneChannels.length > 0) {
+      zones.push({ id: generateZoneId(), name: 'DMR Rptrs', channels: Array.from(new Set(allZoneChannels)) });
+    }
+
+    const newTalkGroups = queuedNewTgs
+      .sort((a, b) => a.index - b.index)
+      .map(({ contactNumber, name, callType, flag }) => ({ contactNumber, name, callType, flag }));
+
+    return { channels, zones, newTalkGroups };
   };
 
   const handleAddRptrsChannels = async () => {
@@ -78,18 +218,29 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       const currentChannels = useChannelsStore.getState().channels;
       const nextChannelNumber = getNextChannelNumber(currentChannels);
 
-      // Generate channels and zones for selected repeaters
-      const result = generateRptrsChannels(
-        nextChannelNumber,
-        selectedRptrsList,
-        rptrsZoneGrouping === 'single',
-        rptrsZoneGrouping === 'location',
-        rptrsSeparateTimeslots
-      );
+      const result = rptrsUseStaticTgs
+        ? await generateStaticTgChannels(selectedRptrsList, nextChannelNumber)
+        : generateRptrsChannels(
+            nextChannelNumber,
+            selectedRptrsList,
+            rptrsZoneGrouping === 'single',
+            rptrsZoneGrouping === 'location',
+            rptrsSeparateTimeslots
+          );
 
       if (result.channels.length === 0) {
-        onError('No channels to add from selected DMR repeaters');
+        onError(
+          rptrsUseStaticTgs
+            ? 'No static talk group channels generated — selected repeaters may not be on BrandMeister, or have none configured'
+            : 'No channels to add from selected DMR repeaters'
+        );
         return;
+      }
+
+      // Commit any newly-created talk groups first, so the channels' contactId
+      // references resolve to real entries as soon as they land in the store.
+      if ('newTalkGroups' in result && result.newTalkGroups.length > 0) {
+        useQuickContactsStore.getState().addContacts(result.newTalkGroups);
       }
 
       // Merge overlaps within the new channels and dedupe against existing ones.
@@ -244,11 +395,26 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"
-                  checked={rptrsSeparateTimeslots}
-                  onChange={(e) => setRptrsSeparateTimeslots(e.target.checked)}
+                  checked={rptrsUseStaticTgs}
+                  onChange={(e) => setRptrsUseStaticTgs(e.target.checked)}
                 />
-                <span className="text-cool-gray">Create separate channels for each timeslot (TS1, TS2)</span>
+                <span className="text-cool-gray">Generate one channel per static talk group instead</span>
               </label>
+              {rptrsUseStaticTgs ? (
+                <div className="text-xs text-cool-gray pl-6">
+                  Only works for BrandMeister repeaters — other networks will be skipped. Each
+                  channel's timeslot comes from the repeater's static talk group assignment.
+                </div>
+              ) : (
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={rptrsSeparateTimeslots}
+                    onChange={(e) => setRptrsSeparateTimeslots(e.target.checked)}
+                  />
+                  <span className="text-cool-gray">Create separate channels for each timeslot (TS1, TS2)</span>
+                </label>
+              )}
               <Button
                 onClick={handleAddRptrsChannels}
                 disabled={isAddingRptrs}
@@ -256,7 +422,9 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
               >
                 {isAddingRptrs
                   ? 'Adding DMR Repeater Channels...'
-                  : `Add ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'DMR Repeater Channel')}`}
+                  : rptrsUseStaticTgs
+                    ? `Add Channels from ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'Repeater')}'s Static Talk Groups`
+                    : `Add ${selectedRptrs.size} ${formatPlural(selectedRptrs.size, 'DMR Repeater Channel')}`}
               </Button>
             </div>
           )}

--- a/src/components/import/sources/RptrsSource.tsx
+++ b/src/components/import/sources/RptrsSource.tsx
@@ -15,6 +15,7 @@ import {
   convertRptrFrequency,
   convertRptrOffset,
   groupRptrsByLocation,
+  getStateAbbrev,
   type RptrData,
 } from '../../../data/rptrsData';
 import { SelectAllButtons } from '../SelectAllButtons';
@@ -34,6 +35,24 @@ interface RptrStaticTgPreview {
   rxFrequency: number;
   txFrequency: number;
   tgs: StaticTgPreviewEntry[];
+}
+
+const DEFAULT_STATIC_TG_NAME_FORMAT = '{call}-{tg}';
+
+/**
+ * Fill a channel-name template with per-channel tokens and truncate to the 16-char
+ * radio limit. Naming conventions vary a lot between operators (callsign vs. city vs.
+ * abbreviated talk group name), so this is user-configurable rather than fixed.
+ */
+function applyChannelNameFormat(
+  format: string,
+  tokens: { call: string; city: string; state: string; tg: string; tgname: string }
+): string {
+  let name = format || DEFAULT_STATIC_TG_NAME_FORMAT;
+  for (const [key, value] of Object.entries(tokens)) {
+    name = name.split(`{${key}}`).join(value);
+  }
+  return name.substring(0, 16);
 }
 
 interface RptrsSourceProps {
@@ -58,6 +77,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   const [rptrsZoneGrouping, setRptrsZoneGrouping] = useState<'location' | 'single'>('location');
   const [rptrsSeparateTimeslots, setRptrsSeparateTimeslots] = useState(true);
   const [rptrsUseStaticTgs, setRptrsUseStaticTgs] = useState(false);
+  const [rptrsChannelNameFormat, setRptrsChannelNameFormat] = useState(DEFAULT_STATIC_TG_NAME_FORMAT);
   const [isAddingRptrs, setIsAddingRptrs] = useState(false);
   const [isLoadingStaticTgs, setIsLoadingStaticTgs] = useState(false);
   const [staticTgPreview, setStaticTgPreview] = useState<RptrStaticTgPreview[] | null>(null);
@@ -221,7 +241,13 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
           });
         }
         return {
-          channelName: `${rptr.callsign}-${tg.talkgroup}`.substring(0, 16),
+          channelName: applyChannelNameFormat(rptrsChannelNameFormat, {
+            call: rptr.callsign,
+            city: rptr.city,
+            state: getStateAbbrev(rptr.state || ''),
+            tg: String(tg.talkgroup),
+            tgname: tg.name,
+          }),
           contactId,
           timeslot: tg.slot,
         };
@@ -380,6 +406,23 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
 
   if (!supportsDigital || rptrs.length === 0) return null;
 
+  const namePreviewRptr = Array.from(selectedRptrs).map(i => rptrs[i]).filter(Boolean)[0];
+  const namePreviewExample = namePreviewRptr
+    ? applyChannelNameFormat(rptrsChannelNameFormat, {
+        call: namePreviewRptr.callsign,
+        city: namePreviewRptr.city,
+        state: getStateAbbrev(namePreviewRptr.state || ''),
+        tg: '3172',
+        tgname: 'Colorado',
+      })
+    : applyChannelNameFormat(rptrsChannelNameFormat, {
+        call: 'K0NXA',
+        city: 'Denver',
+        state: 'CO',
+        tg: '3172',
+        tgname: 'Colorado',
+      });
+
   return (
     <Card padding="tight" className="mb-4">
       <SectionTitle as="h3" size="lg" className="mb-4">DMR Repeaters</SectionTitle>
@@ -503,6 +546,22 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
                   <div className="text-xs text-cool-gray pl-6">
                     Only works for BrandMeister repeaters — other networks will be skipped. Each
                     channel's timeslot comes from the repeater's static talk group assignment.
+                  </div>
+
+                  <div className="pl-6 space-y-1">
+                    <label className="text-xs text-cool-gray block">
+                      Channel name format (tokens: {'{call}'} {'{city}'} {'{state}'} {'{tg}'} {'{tgname}'}, truncated to 16 chars):
+                    </label>
+                    <input
+                      type="text"
+                      value={rptrsChannelNameFormat}
+                      onChange={(e) => setRptrsChannelNameFormat(e.target.value)}
+                      placeholder={DEFAULT_STATIC_TG_NAME_FORMAT}
+                      className="w-full bg-black border border-neon-cyan rounded px-2 py-1 text-white text-sm"
+                    />
+                    <div className="text-xs text-cool-gray">
+                      Preview: <span className="text-neon-cyan">{namePreviewExample}</span>
+                    </div>
                   </div>
 
                   {!staticTgPreview ? (

--- a/src/components/import/sources/RptrsSource.tsx
+++ b/src/components/import/sources/RptrsSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber, selectionCardClass } from '../../../utils/importHelpers';
 import { generateRptrsChannels } from '../../../services/rptrsChannels';
 import { mergeChannelSetsWithExisting } from '../../../services/channelMerger';
@@ -27,8 +28,6 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [rptrsSearchFilter, setRptrsSearchFilter] = useState('');
   const [selectedRptrs, setSelectedRptrs] = useState<Set<number>>(new Set());
   const [rptrsZoneGrouping, setRptrsZoneGrouping] = useState<'location' | 'single'>('location');
@@ -72,7 +71,12 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
         throw new Error('No DMR repeaters selected');
       }
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Read the live channel list at the moment of the click, not a value captured
+      // at render time — if another "Add channels" action ran since this component
+      // last rendered, a stale array here would pick colliding channel numbers and
+      // then blow away those newer channels entirely when committed below.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Generate channels and zones for selected repeaters
       const result = generateRptrsChannels(
@@ -92,11 +96,13 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
       // Existing channels are never renumbered — renumbering them would break
       // every zone and scan list that references them.
       const { channelsToAdd, channelMapping } = mergeChannelSetsWithExisting(
-        channels,
+        currentChannels,
         [result.channels],
         nextChannelNumber
       );
-      setChannels([...channels, ...channelsToAdd]);
+      // Functional append: commits against whatever is in the store right now,
+      // instead of replacing it wholesale with a snapshot that may already be stale.
+      useChannelsStore.getState().addChannels(channelsToAdd);
 
       // Remap the generated zones through the merge mapping: a new channel that
       // collapsed into another (or matched an existing channel) changed number.
@@ -110,7 +116,7 @@ export const RptrsSource: React.FC<RptrsSourceProps> = ({
           )].sort((a, b) => a - b),
         }))
         .filter(zone => zone.channels.length > 0);
-      setZones([...zones, ...remappedZones]);
+      useZonesStore.getState().addZones(remappedZones);
 
       onGenerationResult({
         channels: channelsToAdd.length,

--- a/src/components/import/sources/TaflSource.tsx
+++ b/src/components/import/sources/TaflSource.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatPlural } from '../../../utils/formatPlural';
-import { useImportStores } from '../../../hooks/useImportStores';
+import { useChannelsStore } from '../../../store/channelsStore';
+import { useZonesStore } from '../../../store/zonesStore';
 import { getNextChannelNumber } from '../../../utils/importHelpers';
 import { generateTaflChannels } from '../../../services/taflChannels';
 import { groupTaflEntriesByName, type TaflData } from '../../../data/taflData';
@@ -24,8 +25,6 @@ export const TaflSource: React.FC<TaflSourceProps> = ({
   onError,
   onGenerationResult,
 }) => {
-  const { channels, setChannels, zones, setZones } = useImportStores();
-
   const [taflSearchFilter, setTaflSearchFilter] = useState('');
   const [selectedTaflEntries, setSelectedTaflEntries] = useState<Set<number>>(new Set());
   const [expandedTaflGroups, setExpandedTaflGroups] = useState<Set<string>>(new Set());
@@ -92,7 +91,10 @@ export const TaflSource: React.FC<TaflSourceProps> = ({
         throw new Error('No TAFL entries selected');
       }
 
-      const nextChannelNumber = getNextChannelNumber(channels);
+      // Fresh read at click time — see RptrsSource.tsx for why this can't be the
+      // value captured at render time.
+      const currentChannels = useChannelsStore.getState().channels;
+      const nextChannelNumber = getNextChannelNumber(currentChannels);
 
       // Generate channels and zones for selected entries
       // TAFL always uses individual zones grouped by name
@@ -108,13 +110,11 @@ export const TaflSource: React.FC<TaflSourceProps> = ({
         return;
       }
 
-      // Add channels
-      const updatedChannels = [...channels, ...result.channels];
-      setChannels(updatedChannels);
+      // Add channels — functional append, safe against concurrent add actions
+      useChannelsStore.getState().addChannels(result.channels);
 
       // Add zones
-      const updatedZones = [...zones, ...result.zones];
-      setZones(updatedZones);
+      useZonesStore.getState().addZones(result.zones);
 
       onGenerationResult({
         channels: result.channels.length,

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -24,6 +24,7 @@ import { useAlert } from '../../hooks/useAlert';
 import { ReadProgressModal } from '../ui/ReadProgressModal';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { isWebSerialSupported } from '../../utils/browserSupport';
+import { compactChannelNumbers, remapChannelNumbers, remapChannelNumber } from '../../utils/channelHelpers';
 
 export const Toolbar: React.FC = () => {
   const { channels, setChannels } = useChannelsStore();
@@ -202,11 +203,27 @@ export const Toolbar: React.FC = () => {
       // Lazy load codeplug import when needed
       const { importCodeplug } = await import('../../services/codeplugExport');
       const codeplugData = await importCodeplug(file);
-      
+
+      // Loaded files can predate the read-time gap fix (or be hand-edited), so channel
+      // numbers may not be a contiguous 1..N matching array order. Compact here too and
+      // carry the mapping into zones/scan lists — see compactChannelNumbers for why this
+      // matters (the radio write path packs channels by array position, not .number).
+      const { channels, oldToNew, hadGaps } = compactChannelNumbers(codeplugData.channels);
+
       // Populate all stores with imported data
-      setChannels(codeplugData.channels);
-      setZones(codeplugData.zones);
-      setScanLists(codeplugData.scanLists);
+      setChannels(channels);
+      setZones(hadGaps
+        ? codeplugData.zones.map(z => ({ ...z, channels: remapChannelNumbers(z.channels, oldToNew) }))
+        : codeplugData.zones);
+      setScanLists(hadGaps
+        ? codeplugData.scanLists.map(sl => ({
+            ...sl,
+            channels: remapChannelNumbers(sl.channels, oldToNew),
+            priorityChannel1: remapChannelNumber(sl.priorityChannel1, oldToNew),
+            priorityChannel2: remapChannelNumber(sl.priorityChannel2, oldToNew),
+            designatedTxChannel: remapChannelNumber(sl.designatedTxChannel, oldToNew),
+          }))
+        : codeplugData.scanLists);
       setContacts(codeplugData.contacts);
       setDigitalEmergencies(codeplugData.digitalEmergencies);
       if (codeplugData.digitalEmergencyConfig) {

--- a/src/components/scanlists/ScanListsTab.tsx
+++ b/src/components/scanlists/ScanListsTab.tsx
@@ -1,21 +1,76 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { useScanListsStore } from '../../store/scanListsStore';
 import { formatPlural } from '../../utils/formatPlural';
 import { ScanListsList } from './ScanListsList';
+import { ConfirmModal } from '../ui/ConfirmModal';
+import { CsvExportImportButtons } from '../ui/CsvExportImportButtons';
+import { useAlert } from '../../hooks/useAlert';
+import { exportScanListsToCSV, importScanListsFromCSV, downloadCSV } from '../../services/csv';
+import type { ScanList } from '../../models/ScanList';
 
 export const ScanListsTab: React.FC = () => {
-  const { scanLists } = useScanListsStore();
+  const { scanLists, setScanLists } = useScanListsStore();
+  const { alertOpen, alertMessage, alertTitle, showAlert, closeAlert } = useAlert('Full CSV Export/Import');
+  const [pendingScanListsImport, setPendingScanListsImport] = useState<ScanList[] | null>(null);
+
+  const handleExportScanListsCsv = useCallback(() => {
+    downloadCSV(exportScanListsToCSV(scanLists), 'scanlists.csv');
+  }, [scanLists]);
+
+  const handleImportScanListsFile = useCallback((file: File) => {
+    file.text().then(content => {
+      const result = importScanListsFromCSV(content);
+      if (!result.success || !result.scanLists) {
+        showAlert(result.errors?.join('\n') || 'Failed to import scan lists CSV', 'Import failed');
+        return;
+      }
+      setPendingScanListsImport(result.scanLists);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  }, [showAlert]);
+
+  const handleImportScanListsConfirm = useCallback(() => {
+    if (pendingScanListsImport) {
+      setScanLists(pendingScanListsImport);
+    }
+    setPendingScanListsImport(null);
+  }, [pendingScanListsImport, setScanLists]);
 
   return (
     <div className="h-full">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-2xl font-bold text-neon-cyan">Scan Lists</h2>
-        <div className="text-cool-gray">
-          {scanLists.length} {formatPlural(scanLists.length, 'scan list')}
+        <div className="flex items-center gap-4">
+          <div className="text-cool-gray">
+            {scanLists.length} {formatPlural(scanLists.length, 'scan list')}
+          </div>
+          <CsvExportImportButtons
+            label="scan lists"
+            onExport={handleExportScanListsCsv}
+            onImportFile={handleImportScanListsFile}
+            exportDisabled={scanLists.length === 0}
+          />
         </div>
       </div>
       <ScanListsList />
+      <ConfirmModal
+        isOpen={pendingScanListsImport !== null}
+        onClose={() => setPendingScanListsImport(null)}
+        onConfirm={handleImportScanListsConfirm}
+        title="Import Scan Lists CSV"
+        message={`Replace all ${scanLists.length} existing ${formatPlural(scanLists.length, 'scan list')} with ${pendingScanListsImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+        confirmLabel="Replace"
+        variant="danger"
+      />
+      <ConfirmModal
+        isOpen={alertOpen}
+        onClose={closeAlert}
+        title={alertTitle}
+        message={alertMessage}
+        confirmLabel="OK"
+        variant="alert"
+      />
     </div>
   );
 };
-

--- a/src/components/ui/CsvExportImportButtons.tsx
+++ b/src/components/ui/CsvExportImportButtons.tsx
@@ -1,0 +1,54 @@
+import React, { useRef } from 'react';
+
+interface CsvExportImportButtonsProps {
+  /** Human label used in button tooltips, e.g. "channels" */
+  label: string;
+  onExport: () => void;
+  onImportFile: (file: File) => void;
+  exportDisabled?: boolean;
+}
+
+/**
+ * A small "Export CSV" / "Import CSV" button pair, matching the Channels tab's "+ Add"
+ * button styling. Callers own the actual export/import logic (including any
+ * confirmation before a destructive replace) — this just wires up the file picker.
+ */
+export const CsvExportImportButtons: React.FC<CsvExportImportButtonsProps> = ({
+  label,
+  onExport,
+  onImportFile,
+  exportDisabled,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept=".csv"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onImportFile(file);
+          if (fileInputRef.current) fileInputRef.current.value = '';
+        }}
+      />
+      <button
+        onClick={onExport}
+        disabled={exportDisabled}
+        className="px-2 py-1 text-xs text-cool-gray hover:text-neon-cyan border border-neon-cyan border-opacity-20 hover:border-opacity-50 rounded transition-colors focus:outline-none disabled:opacity-40 disabled:cursor-not-allowed"
+        title={`Export ${label} to CSV`}
+      >
+        Export CSV
+      </button>
+      <button
+        onClick={() => fileInputRef.current?.click()}
+        className="px-2 py-1 text-xs text-cool-gray hover:text-neon-cyan border border-neon-cyan border-opacity-20 hover:border-opacity-50 rounded transition-colors focus:outline-none"
+        title={`Import ${label} from CSV`}
+      >
+        Import CSV
+      </button>
+    </>
+  );
+};

--- a/src/components/zones/ZonesTab.tsx
+++ b/src/components/zones/ZonesTab.tsx
@@ -1,14 +1,45 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useZonesStore } from '../../store/zonesStore';
 import { useChannelsStore } from '../../store/channelsStore';
 import { useLogStore } from '../../store/logStore';
 import { ZonesList } from './ZonesList';
 import { formatPlural } from '../../utils/formatPlural';
+import { ConfirmModal } from '../ui/ConfirmModal';
+import { CsvExportImportButtons } from '../ui/CsvExportImportButtons';
+import { useAlert } from '../../hooks/useAlert';
+import { exportZonesToCSV, importZonesFromCSV, downloadCSV } from '../../services/csv';
+import type { Zone } from '../../models/Zone';
 
 export const ZonesTab: React.FC = () => {
-  const { zones, updateZone } = useZonesStore();
+  const { zones, updateZone, setZones } = useZonesStore();
   const { channels } = useChannelsStore();
   const addLog = useLogStore((s) => s.addLog);
+  const { alertOpen, alertMessage, alertTitle, showAlert, closeAlert } = useAlert('Full CSV Export/Import');
+  const [pendingZonesImport, setPendingZonesImport] = useState<Zone[] | null>(null);
+
+  const handleExportZonesCsv = useCallback(() => {
+    downloadCSV(exportZonesToCSV(zones), 'zones.csv');
+  }, [zones]);
+
+  const handleImportZonesFile = useCallback((file: File) => {
+    file.text().then(content => {
+      const result = importZonesFromCSV(content);
+      if (!result.success || !result.zones) {
+        showAlert(result.errors?.join('\n') || 'Failed to import zones CSV', 'Import failed');
+        return;
+      }
+      setPendingZonesImport(result.zones);
+    }).catch(err => {
+      showAlert(err instanceof Error ? err.message : 'Failed to read CSV file', 'Import failed');
+    });
+  }, [showAlert]);
+
+  const handleImportZonesConfirm = useCallback(() => {
+    if (pendingZonesImport) {
+      setZones(pendingZonesImport);
+    }
+    setPendingZonesImport(null);
+  }, [pendingZonesImport, setZones]);
 
   // On zone page: remove any zone channel refs that point to non-existent channels, and log to debug
   useEffect(() => {
@@ -32,13 +63,38 @@ export const ZonesTab: React.FC = () => {
     <div className="h-full flex flex-col">
       <div className="mb-4 flex items-center justify-between flex-shrink-0">
         <h2 className="text-2xl font-bold text-neon-cyan">Zones</h2>
-        <div className="text-cool-gray">
-          {zones.length} {formatPlural(zones.length, 'zone')}
+        <div className="flex items-center gap-4">
+          <div className="text-cool-gray">
+            {zones.length} {formatPlural(zones.length, 'zone')}
+          </div>
+          <CsvExportImportButtons
+            label="zones"
+            onExport={handleExportZonesCsv}
+            onImportFile={handleImportZonesFile}
+            exportDisabled={zones.length === 0}
+          />
         </div>
       </div>
       <div className="flex-1 min-h-0">
         <ZonesList />
       </div>
+      <ConfirmModal
+        isOpen={pendingZonesImport !== null}
+        onClose={() => setPendingZonesImport(null)}
+        onConfirm={handleImportZonesConfirm}
+        title="Import Zones CSV"
+        message={`Replace all ${zones.length} existing ${formatPlural(zones.length, 'zone')} with ${pendingZonesImport?.length ?? 0} imported from CSV? This cannot be undone.`}
+        confirmLabel="Replace"
+        variant="danger"
+      />
+      <ConfirmModal
+        isOpen={alertOpen}
+        onClose={closeAlert}
+        title={alertTitle}
+        message={alertMessage}
+        confirmLabel="OK"
+        variant="alert"
+      />
     </div>
   );
 };

--- a/src/data/rptrsData.ts
+++ b/src/data/rptrsData.ts
@@ -238,7 +238,7 @@ export function groupRptrsByNetwork(
 /**
  * Get state abbreviation (simple mapping for common states)
  */
-function getStateAbbrev(state: string): string {
+export function getStateAbbrev(state: string): string {
   // Common state abbreviations - expand as needed
   const stateMap: Record<string, string> = {
     'California': 'CA',

--- a/src/hooks/useRadioConnection.ts
+++ b/src/hooks/useRadioConnection.ts
@@ -23,6 +23,8 @@ import type { Zone } from '../models/Zone';
 import type { ScanList } from '../models/ScanList';
 import { isValidChannelFrequency } from '../services/validation/frequencyValidator';
 import { parseBootImageHeader } from '../utils/bootImage';
+import { compactChannelNumbers, remapChannelNumbers, remapChannelNumber } from '../utils/channelHelpers';
+import { log } from '../utils/protocolLogger';
 
 /** Augment error message when tab was hidden during a serial operation (better reporting). */
 function withVisibilityContext(message: string, tabWentHidden: boolean): string {
@@ -143,7 +145,18 @@ export function useRadioConnection() {
       }
 
       onProgress?.(20, 'Parsing channels...', steps[4]);
-      const channels = await proto.readChannels();
+      const rawChannels = await proto.readChannels();
+
+      // Blank slots on the radio are skipped without reserving their number, so
+      // channel.number can come back with gaps relative to array order. The write
+      // path packs channels purely by array position (ignoring .number), and
+      // zones/scan lists reference channels by raw .number — so an uncompacted gap
+      // causes the next write to silently shift channels into the wrong physical
+      // slot. Compact to 1..N here and carry the mapping into zones/scan lists below.
+      const { channels, oldToNew, hadGaps } = compactChannelNumbers(rawChannels);
+      if (hadGaps) {
+        log.warn(`Channel numbers had gaps (likely blank slots on the radio) — renumbered ${rawChannels.length} channels to a contiguous 1..${channels.length} sequence`, 'Connection');
+      }
       setChannels(channels);
 
       // Enrich radioInfo with firmware from cached image (UV5R-Mini and DM-32UV)
@@ -154,7 +167,16 @@ export function useRadioConnection() {
       }
 
       if (dm32) {
-        setRawChannelData(dm32.rawChannelData);
+        let rawChannelData = dm32.rawChannelData;
+        if (hadGaps) {
+          const remapped: typeof dm32.rawChannelData = new Map();
+          for (const [oldNum, raw] of rawChannelData.entries()) {
+            const newNum = oldToNew.get(oldNum);
+            if (newNum !== undefined) remapped.set(newNum, raw);
+          }
+          rawChannelData = remapped;
+        }
+        setRawChannelData(rawChannelData);
         setBlockMetadata(new Map(dm32.blockMetadata));
         setBlockData(new Map(dm32.blockData));
       }
@@ -168,13 +190,25 @@ export function useRadioConnection() {
       onProgress?.(70, 'Parsing configuration from cache...', steps[5]);
 
       if (caps?.supportsZones) {
-        const zones = await proto.readZones();
+        let zones = await proto.readZones();
+        if (hadGaps) {
+          zones = zones.map(z => ({ ...z, channels: remapChannelNumbers(z.channels, oldToNew) }));
+        }
         setZones(zones);
         if (dm32) setRawZoneData(dm32.rawZoneData);
       }
 
       if (caps?.supportsScanLists) {
-        const scanLists = await proto.readScanLists();
+        let scanLists = await proto.readScanLists();
+        if (hadGaps) {
+          scanLists = scanLists.map(sl => ({
+            ...sl,
+            channels: remapChannelNumbers(sl.channels, oldToNew),
+            priorityChannel1: remapChannelNumber(sl.priorityChannel1, oldToNew),
+            priorityChannel2: remapChannelNumber(sl.priorityChannel2, oldToNew),
+            designatedTxChannel: remapChannelNumber(sl.designatedTxChannel, oldToNew),
+          }));
+        }
         setScanLists(scanLists);
         if (dm32) setRawScanListData(dm32.rawScanListData);
       }
@@ -557,32 +591,39 @@ export function useRadioConnection() {
       // Filter channels to only include those with valid frequencies (use effective model for capabilities)
       const effectiveModel = radioInfo?.model ?? selectedRadioModel ?? null;
       const bandLimits = getCapabilitiesForModel(effectiveModel)?.bandLimits;
-      const validChannels = channels.filter(ch => isValidChannelFrequency(ch, bandLimits));
-      const filteredCount = channels.length - validChannels.length;
-      
+      const rawValidChannels = channels.filter(ch => isValidChannelFrequency(ch, bandLimits));
+      const filteredCount = channels.length - rawValidChannels.length;
+
       if (filteredCount > 0) {
         console.warn(`Filtered out ${filteredCount} channel(s) with frequencies outside supported ranges`);
       }
-      
-      // Update zones to only include channel numbers that exist (never write zone refs to non-existent channels)
-      const validChannelNumbers = new Set(validChannels.map(ch => ch.number));
+
+      // Filtering can leave gaps in channel.number relative to array order (e.g. channel 51
+      // removed, 52+ unchanged). generateChannelBlocks() packs channels purely by array
+      // position and ignores .number, so an uncompacted gap here silently shifts every
+      // subsequent channel into the wrong physical slot while zone/scan-list references
+      // still point at the old numbers. Compact first, then remap references through the
+      // same mapping (this also drops refs to channels that were actually filtered out).
+      const { channels: validChannels, oldToNew } = compactChannelNumbers(rawValidChannels);
+
       const filteredZones = zones.map(zone => {
-        const invalidRefs = zone.channels.filter(chNum => !validChannelNumbers.has(chNum));
-        if (invalidRefs.length > 0) {
+        const remapped = remapChannelNumbers(zone.channels, oldToNew);
+        const droppedCount = zone.channels.length - remapped.length;
+        if (droppedCount > 0) {
           console.warn(
-            `[Zones] Zone "${zone.name}" referenced non-existent channel(s): ${invalidRefs.join(', ')}. Removed before write to prevent radio errors.`
+            `[Zones] Zone "${zone.name}" referenced ${droppedCount} filtered-out channel(s). Removed before write to prevent radio errors.`
           );
         }
-        return {
-          ...zone,
-          channels: zone.channels.filter(chNum => validChannelNumbers.has(chNum))
-        };
+        return { ...zone, channels: remapped };
       }).filter(zone => zone.channels.length > 0); // Remove empty zones
-      
+
       // Update scan lists to only include valid channel numbers
       const filteredScanLists = scanLists.map(scanList => ({
         ...scanList,
-        channels: scanList.channels.filter(chNum => validChannelNumbers.has(chNum))
+        channels: remapChannelNumbers(scanList.channels, oldToNew),
+        priorityChannel1: remapChannelNumber(scanList.priorityChannel1, oldToNew),
+        priorityChannel2: remapChannelNumber(scanList.priorityChannel2, oldToNew),
+        designatedTxChannel: remapChannelNumber(scanList.designatedTxChannel, oldToNew),
       })).filter(scanList => scanList.channels.length > 0); // Remove empty scan lists
       
       // Use protocol for connected radio (write path)

--- a/src/models/Channel.ts
+++ b/src/models/Channel.ts
@@ -31,7 +31,8 @@ export interface Channel {
   unknown1A_6_4: number;      // Bits 6-4: Unknown Setting (0-3, values ≥4 reset to 0)
   unknown1A_3: boolean;       // Bit 3: Unknown
   aprsReceive: boolean;       // Bit 2: 0=Off, 1=On
-  
+  unknown1A_1_0: number;      // Bits 1-0: Unknown, but OEM CPS writes 3 on every channel - preserve, don't zero
+
   // Emergency Settings (0x1B)
   emergencyIndicator: boolean; // Bit 7: 0=Off, 1=On
   emergencyAck: boolean;       // Bit 6: 0=Off, 1=On

--- a/src/radios/dm32uv/constants.ts
+++ b/src/radios/dm32uv/constants.ts
@@ -18,7 +18,9 @@ export const METADATA = {
   METADATA_0x0B: 0x0B,      // Metadata block 0x0B
   RX_GROUPS: 0x0F,          // DMR RX Groups (DMR Receive Groups) - separate from V-frame 0x0F
   CALIBRATION: 0x02,        // Frequency adjustment/calibration data
-  METADATA_0x44: 0x44,      // Metadata block 0x44 (Talk Groups)
+  METADATA_0x44: 0x44,      // Metadata block 0x44 (Talk Groups, first block)
+  TALK_GROUP_FIRST: 0x44,   // First Talk Groups block
+  TALK_GROUP_LAST: 0x48,    // Last Talk Groups block (5 blocks total — DM32-Protocol-Spec 05-DATA-STRUCTURES.md, confirmed by OEM CPS write capture walking 0x44-0x48 contiguously)
   METADATA_0x06: 0x06,      // Metadata block 0x06 (Config section 4 - contains Talk Groups counter at 0x1FF)
   TX_CONTACT_LOW: 0x42,     // TX Contact for channels 1-2048 (2 bytes per channel)
   TX_CONTACT_HIGH: 0x43,    // TX Contact for channels 2049+ and VFOs (2 bytes per channel)

--- a/src/radios/dm32uv/memory.ts
+++ b/src/radios/dm32uv/memory.ts
@@ -10,7 +10,7 @@ import { log } from '../../utils/protocolLogger';
 export interface MemoryBlock {
   address: number;
   metadata: number;
-  type: 'channel' | 'zone' | 'contact' | 'scan' | 'rxgroup' | 'message' | 'vfo' | 'digitalemergency' | 'analogemergency' | 'dmrradioid' | 'calibration' | 'config' | 'empty' | 'unknown';
+  type: 'channel' | 'zone' | 'talkgroup' | 'contact' | 'scan' | 'rxgroup' | 'message' | 'vfo' | 'digitalemergency' | 'analogemergency' | 'dmrradioid' | 'calibration' | 'config' | 'empty' | 'unknown';
 }
 
 /**
@@ -48,6 +48,8 @@ export async function discoverMemoryBlocks(
       type = 'channel'; // Channel blocks (0x12 = first, 0x41 = last)
     } else if (metadata >= 0x5c && metadata <= 0x64) {
       type = 'zone'; // Zone blocks (0x5c = first, 0x64 = last, 9 blocks) — extended from the single 0x5c value identified in debug export analysis to cover LIMITS.ZONES_MAX (250)
+    } else if (metadata >= 0x44 && metadata <= 0x48) {
+      type = 'talkgroup'; // Talk Groups blocks (0x44 = first, 0x48 = last, 5 blocks) — previously only 0x44 was read, capping the list at ~170 entries instead of the advertised 800
     } else if (metadata === 0x11) {
       type = 'scan'; // Scan lists identified as metadata 0x11 (17) from debug export analysis
     } else if (metadata === 0x03) {
@@ -92,11 +94,12 @@ export async function discoverMemoryBlocks(
 
   const channelCount = blocks.filter(b => b.type === 'channel').length;
   const zoneCount = blocks.filter(b => b.type === 'zone').length;
+  const talkGroupCount = blocks.filter(b => b.type === 'talkgroup').length;
   const scanCount = blocks.filter(b => b.type === 'scan').length;
   const unknownCount = blocks.filter(b => b.type === 'unknown').length;
   const emptyCount = blocks.filter(b => b.type === 'empty').length;
-  
-  log.info(`Discovered ${blocks.length} blocks: Channels=${channelCount}, Zones=${zoneCount}, Scan Lists=${scanCount}, Unknown=${unknownCount}, Empty=${emptyCount}`, 'Memory');
+
+  log.info(`Discovered ${blocks.length} blocks: Channels=${channelCount}, Zones=${zoneCount}, Talk Group blocks=${talkGroupCount}, Scan Lists=${scanCount}, Unknown=${unknownCount}, Empty=${emptyCount}`, 'Memory');
   
   // Log unknown metadata values for investigation
   if (unknownCount > 0) {

--- a/src/radios/dm32uv/protocol.ts
+++ b/src/radios/dm32uv/protocol.ts
@@ -636,11 +636,16 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
       log.error('Radio Settings block (metadata 0x04) is missing from blocks to read!', 'Protocol');
     }
 
-    // Step 2c: Add zone and scan list blocks
+    // Step 2c: Add zone, scan list, and talk group blocks
+    // Talk Groups span metadata 0x44-0x48 (5 blocks) — 0x44 alone is also in
+    // fixedMetadataBlocks above for the "critical/missing" warning; the dedup below
+    // handles the overlap.
     const zoneBlocks = blocks.filter(b => b.type === 'zone');
     const scanBlocks = blocks.filter(b => b.type === 'scan');
+    const talkGroupBlocks = blocks.filter(b => b.type === 'talkgroup');
     blocksToRead.push(...zoneBlocks);
     blocksToRead.push(...scanBlocks);
+    blocksToRead.push(...talkGroupBlocks);
 
     // Step 2d: Add other data type blocks
     const messageBlocks = blocks.filter(b => b.type === 'message');
@@ -2469,26 +2474,37 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
 
     this.onProgress?.(0, 'Parsing Talk Groups from cached blocks...');
 
-    // Find metadata block 0x44
-    const quickContactBlock = this.discoveredBlocks.find(b => b.metadata === METADATA.METADATA_0x44);
-    if (!quickContactBlock) {
+    // Talk Groups span metadata 0x44-0x48 (5 blocks, up to 800 entries) — reading only 0x44
+    // caps the list at whatever fits in one 4KB block (~170 entries).
+    const talkGroupBlocks = this.discoveredBlocks
+      .filter(b => b.metadata >= METADATA.TALK_GROUP_FIRST && b.metadata <= METADATA.TALK_GROUP_LAST)
+      .sort((a, b) => a.metadata - b.metadata);
+    if (talkGroupBlocks.length === 0) {
       // Talk Groups are optional - return empty array if not found
-      log.debug('Talk Groups block (metadata 0x44) not found', 'Protocol');
-      return [];
-    }
-
-    const cachedBlock = this.getCachedBlockByAddress(quickContactBlock.address);
-    if (!cachedBlock) {
-      log.warn(`Talk Groups block at 0x${quickContactBlock.address.toString(16)} not found in cache`, 'Protocol');
+      log.debug('Talk Groups block(s) (metadata 0x44-0x48) not found', 'Protocol');
       return [];
     }
 
     // Parse from cached data only - no radio access
     // Wrap in try-catch to ensure parsing errors don't propagate and affect other parsing
     try {
-      const contacts = parseQuickContacts(cachedBlock.data);
-      this.onProgress?.(100, `Successfully processed ${contacts.length} talk groups`);
-      return contacts;
+      const allContacts: QuickContact[] = [];
+      let nextIndex = 1;
+      for (const block of talkGroupBlocks) {
+        const cachedBlock = this.getCachedBlockByAddress(block.address);
+        if (!cachedBlock) {
+          log.warn(`Talk Groups block 0x${block.metadata.toString(16)} at 0x${block.address.toString(16)} not found in cache`, 'Protocol');
+          continue;
+        }
+        // Exclude the trailing metadata byte (offset 0xFFF) — entries never span it, so it
+        // must not be fed into the entry parser as if it were entry data.
+        const usableData = cachedBlock.data.slice(0, BLOCK_SIZE.STANDARD - 1);
+        const { contacts, nextIndex: blockNextIndex } = parseQuickContacts(usableData, undefined, nextIndex);
+        allContacts.push(...contacts);
+        nextIndex = blockNextIndex;
+      }
+      this.onProgress?.(100, `Successfully processed ${allContacts.length} talk groups`);
+      return allContacts;
     } catch (error) {
       log.error('Error parsing Talk Groups - returning empty array to prevent blocking other parsing', 'Protocol', error);
       // Return empty array instead of throwing - parsing errors should not block other operations
@@ -2512,6 +2528,27 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
 
     if (contacts.length > LIMITS.TALK_GROUPS_MAX) {
       throw new Error(`Maximum of ${LIMITS.TALK_GROUPS_MAX} talk groups allowed. Got ${contacts.length}`);
+    }
+
+    // Talk Groups physically span metadata blocks 0x44-0x48 (5 blocks), but this function
+    // (and encodeQuickContacts) only ever writes block 0x44. Reading now correctly surfaces
+    // all 5 blocks' worth of entries (up to LIMITS.TALK_GROUPS_MAX), so a list read from a
+    // radio with more than one block's worth of talk groups can exceed what this write path
+    // can safely hold — encodeQuickContacts silently truncates past capacity, which would
+    // otherwise mean writing a shorter, truncated list back over the radio's real one.
+    // Block 0x44's real capacity: 1 header byte + N entries (25 bytes for entry 1, 24 each
+    // after) + a 24-byte sentinel must fit in 4095 usable bytes (byte 0xFFF is metadata) —
+    // ~169 real entries. Refuse rather than silently drop the rest until multi-block write
+    // support exists.
+    const SINGLE_BLOCK_TALK_GROUP_MAX = 169;
+    if (contacts.length > SINGLE_BLOCK_TALK_GROUP_MAX) {
+      throw new Error(
+        `Writing ${contacts.length} talk groups isn't supported yet — NeonPlug only writes to the ` +
+        `first Talk Groups block (metadata 0x44), which holds about ${SINGLE_BLOCK_TALK_GROUP_MAX} entries. ` +
+        `Talk Groups actually span 5 blocks (0x44-0x48) on the radio, but multi-block writing hasn't been ` +
+        `implemented yet. Writing now would silently drop everything past ${SINGLE_BLOCK_TALK_GROUP_MAX} ` +
+        `entries. Use the OEM CPS to manage Talk Groups until this is added.`
+      );
     }
 
     this.onProgress?.(0, 'Preparing to write Talk Groups...');

--- a/src/radios/dm32uv/protocol.ts
+++ b/src/radios/dm32uv/protocol.ts
@@ -2699,11 +2699,28 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
                 0x40 // Default to Group Call
     }));
 
+    // STOPGAP: each table entry below stores the Talk Group's physical position (0x44-0x48
+    // index) in a single byte (0-255). With more than 255 Talk Groups, positions beyond
+    // 255 wrap via truncation (e.g. 607 -> 95) and silently alias onto whichever entry
+    // really sits at that lower position — the OEM CPS then displays wrong/blank data for
+    // both the aliased entry and whatever legitimately occupies position 95. The true
+    // format for representing positions >255 here isn't confirmed against real hardware
+    // yet, so those entries are left out of both sorted tables entirely rather than
+    // written with a corrupting wrapped index. NeonPlug's own Talk Groups list reads
+    // directly from 0x44-0x48 and is unaffected either way — this only impacts the OEM
+    // CPS's sorted/quick-lookup views for lists bigger than 255.
+    const oversizedCount = contactsWithIndices.filter(item => item.contactIndex > 255).length;
+    if (oversizedCount > 0) {
+      log.warn(`${oversizedCount} talk group(s) past physical position 255 omitted from the Quick Access Contact List (0x0B) sorted tables to avoid index wraparound corruption in the OEM CPS`, 'Protocol');
+    }
+
     // Index Table 1 (@ 0x100): Sort entries alphabetically by Talk Group name (ASCII string comparison)
-    const sortedByName = [...contactsWithIndices].sort((a, b) => 
-      a.name.localeCompare(b.name, undefined, { sensitivity: 'base', numeric: true })
-    );
-    
+    const sortedByName = [...contactsWithIndices]
+      .filter(item => item.contactIndex <= 255)
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base', numeric: true })
+      );
+
     sortedByName.forEach((item, displayIndex) => {
       const offset = 0x100 + (displayIndex * 2);
       if (offset < 0x700) {
@@ -2721,10 +2738,12 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     });
 
     // Index Table 2 (@ 0x740): Sort entries by DMR ID numerically (lowest ID first)
-    const sortedByDmrId = [...contactsWithIndices].sort((a, b) => 
-      a.contactNumber - b.contactNumber
-    );
-    
+    const sortedByDmrId = [...contactsWithIndices]
+      .filter(item => item.contactIndex <= 255)
+      .sort((a, b) =>
+        a.contactNumber - b.contactNumber
+      );
+
     sortedByDmrId.forEach((item, displayIndex) => {
       const offset = 0x740 + (displayIndex * 2);
       if (offset < 0xD00) {

--- a/src/radios/dm32uv/protocol.ts
+++ b/src/radios/dm32uv/protocol.ts
@@ -2699,34 +2699,32 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
                 0x40 // Default to Group Call
     }));
 
-    // STOPGAP: each table entry below stores the Talk Group's physical position (0x44-0x48
-    // index) in a single byte (0-255). With more than 255 Talk Groups, positions beyond
-    // 255 wrap via truncation (e.g. 607 -> 95) and silently alias onto whichever entry
-    // really sits at that lower position — the OEM CPS then displays wrong/blank data for
-    // both the aliased entry and whatever legitimately occupies position 95. The true
-    // format for representing positions >255 here isn't confirmed against real hardware
-    // yet, so those entries are left out of both sorted tables entirely rather than
-    // written with a corrupting wrapped index. NeonPlug's own Talk Groups list reads
-    // directly from 0x44-0x48 and is unaffected either way — this only impacts the OEM
-    // CPS's sorted/quick-lookup views for lists bigger than 255.
-    const oversizedCount = contactsWithIndices.filter(item => item.contactIndex > 255).length;
-    if (oversizedCount > 0) {
-      log.warn(`${oversizedCount} talk group(s) past physical position 255 omitted from the Quick Access Contact List (0x0B) sorted tables to avoid index wraparound corruption in the OEM CPS`, 'Protocol');
-    }
-
-    // Index Table 1 (@ 0x100): Sort entries alphabetically by Talk Group name (ASCII string comparison)
-    const sortedByName = [...contactsWithIndices]
-      .filter(item => item.contactIndex <= 255)
-      .sort((a, b) =>
-        a.name.localeCompare(b.name, undefined, { sensitivity: 'base', numeric: true })
-      );
+    // Each table entry packs the Talk Group's physical position (0x44-0x48 index) across
+    // BOTH bytes, not just the first: byte0 is the index's low 8 bits, and byte1's low
+    // nibble is the index's next 4 bits (giving a 12-bit index, up to 4095 — well past
+    // LIMITS.TALK_GROUPS_MAX) while byte1's HIGH nibble carries the call type (0x30/0x40/0x50),
+    // the same 12-bit-index-plus-4-bit-type packing already used for the channel -> Talk
+    // Group link at metadata 0x42/0x43. A real OEM CPS write of 607 Talk Groups confirmed
+    // this: Index Table 2 (sorted by DMR ID) held "5F 42" for its 2nd entry, which decodes
+    // to index (0x42 & 0x0F) << 8 | 0x5F = 607 (physical position of "Local", a very
+    // low-DMR-ID entry) with type 0x42 & 0xF0 = 0x40 (Group Call) — matching exactly.
+    // Treating byte1 as a plain 1-byte type (the previous, pre-fix assumption) only
+    // happened to work for lists under 256 entries, where the index's high nibble is
+    // always 0.
+    // Plain codepoint/byte-order comparison, not locale-aware — hardware-confirmed against
+    // the same 607-entry write: the OEM CPS sorts "ALERT-K4NWS" before "Alabama" (uppercase
+    // 'E' < lowercase 'a' in byte order), which a case-insensitive/numeric-aware
+    // localeCompare gets backwards.
+    const sortedByName = [...contactsWithIndices].sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+    );
 
     sortedByName.forEach((item, displayIndex) => {
       const offset = 0x100 + (displayIndex * 2);
       if (offset < 0x700) {
-        quickAccessData[offset] = item.contactIndex;
-        quickAccessData[offset + 1] = item.typeByte;
-        
+        quickAccessData[offset] = item.contactIndex & 0xFF;
+        quickAccessData[offset + 1] = item.typeByte | ((item.contactIndex >> 8) & 0x0F);
+
         // Clear bit in bitmask (0 = used, 1 = free)
         // Use displayIndex for bitmask position, not contactIndex
         const byteIdx = Math.floor(displayIndex / 8);
@@ -2737,18 +2735,21 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
       }
     });
 
-    // Index Table 2 (@ 0x740): Sort entries by DMR ID numerically (lowest ID first)
-    const sortedByDmrId = [...contactsWithIndices]
-      .filter(item => item.contactIndex <= 255)
-      .sort((a, b) =>
-        a.contactNumber - b.contactNumber
-      );
+    // Index Table 2 (@ 0x740): Sort entries by DMR ID numerically (lowest ID first).
+    // Entries with contactNumber 0 (no real DMR ID) still occupy a sorted slot (sorting
+    // first, as ID 0) but that slot is left blank rather than written — hardware-confirmed:
+    // a contactNumber-0 entry's slot in a real OEM CPS write was "FF FF" while the very
+    // next slot held the next-lowest real ID. Skipping the slot's displayIndex entirely
+    // (i.e. filtering it out before assigning positions) was tried first and shifted every
+    // other entry's position by one relative to real hardware output — wrong.
+    const sortedByDmrId = [...contactsWithIndices].sort((a, b) => a.contactNumber - b.contactNumber);
 
     sortedByDmrId.forEach((item, displayIndex) => {
+      if (item.contactNumber === 0) return;
       const offset = 0x740 + (displayIndex * 2);
       if (offset < 0xD00) {
-        quickAccessData[offset] = item.contactIndex;
-        quickAccessData[offset + 1] = item.typeByte;
+        quickAccessData[offset] = item.contactIndex & 0xFF;
+        quickAccessData[offset + 1] = item.typeByte | ((item.contactIndex >> 8) & 0x0F);
       }
     });
 

--- a/src/radios/dm32uv/protocol.ts
+++ b/src/radios/dm32uv/protocol.ts
@@ -15,7 +15,7 @@ import {
   storeRawData,
   type MemoryBlock,
 } from './memory';
-import { parseChannel, parseZones, parseScanLists, parseContactEntry, encodeChannel, encodeZone, encodeScanList, encodeContactEntry, parseRadioSettings, encodeRadioSettings, encodeDigitalEmergencies, encodeAnalogEmergencies, encodeEncryptionKey, parseQuickMessages, parseDMRRadioIDs, encodeDMRRadioID, parseCalibration, parseRXGroups, parseQuickContacts, encodeQuickContacts, encodeQuickMessages, parseTxContactForChannel, encodeTxContactForChannel, encodeRXGroups } from './structures';
+import { parseChannel, parseZones, parseScanLists, parseContactEntry, encodeChannel, encodeZone, encodeScanList, encodeContactEntry, parseRadioSettings, encodeRadioSettings, encodeDigitalEmergencies, encodeAnalogEmergencies, encodeEncryptionKey, parseQuickMessages, parseDMRRadioIDs, encodeDMRRadioID, parseCalibration, parseRXGroups, parseQuickContacts, encodeQuickContactsBlocks, encodeQuickMessages, parseTxContactForChannel, encodeTxContactForChannel, encodeRXGroups } from './structures';
 import type { RadioInfo, DM32Protocol } from '../../types/radio';
 import { BaseDigitalProtocol } from '../shared/BaseProtocols';
 import type { Channel, Zone, Contact, RadioSettings, ScanList, DigitalEmergency, DigitalEmergencyConfig, AnalogEmergency, QuickTextMessage, DMRRadioID, Calibration, RXGroup, QuickContact, EncryptionKey } from '../../models';
@@ -2530,27 +2530,6 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
       throw new Error(`Maximum of ${LIMITS.TALK_GROUPS_MAX} talk groups allowed. Got ${contacts.length}`);
     }
 
-    // Talk Groups physically span metadata blocks 0x44-0x48 (5 blocks), but this function
-    // (and encodeQuickContacts) only ever writes block 0x44. Reading now correctly surfaces
-    // all 5 blocks' worth of entries (up to LIMITS.TALK_GROUPS_MAX), so a list read from a
-    // radio with more than one block's worth of talk groups can exceed what this write path
-    // can safely hold — encodeQuickContacts silently truncates past capacity, which would
-    // otherwise mean writing a shorter, truncated list back over the radio's real one.
-    // Block 0x44's real capacity: 1 header byte + N entries (25 bytes for entry 1, 24 each
-    // after) + a 24-byte sentinel must fit in 4095 usable bytes (byte 0xFFF is metadata) —
-    // ~169 real entries. Refuse rather than silently drop the rest until multi-block write
-    // support exists.
-    const SINGLE_BLOCK_TALK_GROUP_MAX = 169;
-    if (contacts.length > SINGLE_BLOCK_TALK_GROUP_MAX) {
-      throw new Error(
-        `Writing ${contacts.length} talk groups isn't supported yet — NeonPlug only writes to the ` +
-        `first Talk Groups block (metadata 0x44), which holds about ${SINGLE_BLOCK_TALK_GROUP_MAX} entries. ` +
-        `Talk Groups actually span 5 blocks (0x44-0x48) on the radio, but multi-block writing hasn't been ` +
-        `implemented yet. Writing now would silently drop everything past ${SINGLE_BLOCK_TALK_GROUP_MAX} ` +
-        `entries. Use the OEM CPS to manage Talk Groups until this is added.`
-      );
-    }
-
     this.onProgress?.(0, 'Preparing to write Talk Groups...');
 
     // Discover blocks if not already discovered
@@ -2571,9 +2550,12 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
       this.discoveredBlocks = blocks;
     }
 
-    // Find metadata block 0x44 (Talk Groups data)
-    const quickContactBlock = this.discoveredBlocks.find(b => b.metadata === METADATA.METADATA_0x44);
-    if (!quickContactBlock) {
+    // Find Talk Groups blocks (metadata 0x44-0x48, 5 blocks) — sorted so entries are
+    // written in the same order as encodeQuickContactsBlocks() expects them.
+    const quickContactBlocks = this.discoveredBlocks
+      .filter(b => b.metadata >= METADATA.TALK_GROUP_FIRST && b.metadata <= METADATA.TALK_GROUP_LAST)
+      .sort((a, b) => a.metadata - b.metadata);
+    if (quickContactBlocks.length === 0) {
       throw new Error('Talk Groups block (metadata 0x44) not found');
     }
 
@@ -2591,8 +2573,10 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
 
     this.onProgress?.(10, 'Encoding Talk Groups...');
 
-    // Encode contacts to 4KB block
-    const blockData = encodeQuickContacts(contacts);
+    // Encode contacts across as many Talk Groups blocks as needed (overflow past one
+    // block spills into the next, matching the per-block layout confirmed against a real
+    // OEM CPS write capture).
+    const encodedBlocks = encodeQuickContactsBlocks(contacts, quickContactBlocks.map(b => b.metadata));
 
     // Get block 0x06 from cache or read it fresh
     this.onProgress?.(30, 'Preparing config block 0x06...');
@@ -2621,24 +2605,20 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     await this.connection!.writeMemory(counterBlock.address, counterBlockData, METADATA.METADATA_0x06);
     log.info(`Updated Talk Groups counter to ${contacts.length} at block 0x06 offset 0x1FF`, 'Protocol');
 
-    // Write the Talk Groups data block
-    this.onProgress?.(70, 'Writing Talk Groups data to radio...');
-    await this.connection!.writeMemory(quickContactBlock.address, blockData, METADATA.METADATA_0x44);
+    // Write the Talk Groups data blocks
+    this.onProgress?.(70, `Writing Talk Groups data to ${quickContactBlocks.length} block(s)...`);
+    for (let i = 0; i < quickContactBlocks.length; i++) {
+      const block = quickContactBlocks[i];
+      const data = encodedBlocks[i];
+      await this.connection!.writeMemory(block.address, data, block.metadata);
 
-    // Update cache (store the written data)
-    const cachedBlockIndex = this.cachedBlockData.findIndex(b => b.address === quickContactBlock.address);
-    if (cachedBlockIndex >= 0) {
-      this.cachedBlockData[cachedBlockIndex] = {
-        metadata: METADATA.METADATA_0x44,
-        address: quickContactBlock.address,
-        data: blockData,
-      };
-    } else {
-      this.cachedBlockData.push({
-        metadata: METADATA.METADATA_0x44,
-        address: quickContactBlock.address,
-        data: blockData,
-      });
+      // Update cache (store the written data)
+      const cachedBlockIndex = this.cachedBlockData.findIndex(b => b.address === block.address);
+      if (cachedBlockIndex >= 0) {
+        this.cachedBlockData[cachedBlockIndex] = { metadata: block.metadata, address: block.address, data };
+      } else {
+        this.cachedBlockData.push({ metadata: block.metadata, address: block.address, data });
+      }
     }
 
     // Update cache for counter block too
@@ -2779,7 +2759,7 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     // This allows users to download the original raw data from the radio
 
     this.onProgress?.(100, `Successfully wrote ${contacts.length} talk groups`);
-    log.info(`Successfully wrote ${contacts.length} talk groups to blocks 0x44, 0x06, and 0x0B`, 'Protocol');
+    log.info(`Successfully wrote ${contacts.length} talk groups across ${quickContactBlocks.length} block(s) (0x44-0x${quickContactBlocks[quickContactBlocks.length - 1].metadata.toString(16)}), plus 0x06 and 0x0B`, 'Protocol');
   }
 
   /**

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -3356,8 +3356,12 @@ export function parseQuickContacts(
     const entryStartOffset = offset;
     let hasHeader = false;
 
-    // Check if this is Contact 1 with 1-byte header (0x00)
-    if (contactIndex === 1 && offset + 1 <= data.length) {
+    // Check for a 1-byte header (0x00) at the start of THIS buffer — every Talk Groups
+    // block (0x44-0x48) has its own leading header before its first entry, not just the
+    // very first block. Checking offset===0 (rather than contactIndex===1) means this
+    // correctly re-triggers for each block when parseQuickContacts is called once per
+    // block with a fresh buffer, instead of only ever matching the global first entry.
+    if (offset === 0 && offset + 1 <= data.length) {
       const header = data[offset];
       if (header === 0x00) {
         hasHeader = true;

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -3335,13 +3335,22 @@ export function encodeRXGroups(
  * - Variable-length name (null-terminated)
  * - Remaining bytes: padding + 3-byte contact number + 1-byte call type + padding
  */
+export interface ParseQuickContactsResult {
+  contacts: QuickContact[];
+  /** Next 1-based index after this block — physical slot position continues across the
+   *  Talk Groups block range (0x44-0x48), so callers parsing multiple blocks must pass
+   *  this back in as the next block's startIndex. */
+  nextIndex: number;
+}
+
 export function parseQuickContacts(
   data: Uint8Array,
-  onRawContactParsed?: (contactIndex: number, rawData: Uint8Array, name: string) => void
-): QuickContact[] {
+  onRawContactParsed?: (contactIndex: number, rawData: Uint8Array, name: string) => void,
+  startIndex: number = 1
+): ParseQuickContactsResult {
   const contacts: QuickContact[] = [];
   let offset = 0;
-  let contactIndex = 1; // 1-based index
+  let contactIndex = startIndex; // 1-based physical slot position
 
   while (offset < data.length) {
     const entryStartOffset = offset;
@@ -3448,7 +3457,7 @@ export function parseQuickContacts(
     contactIndex++;
   }
 
-  return contacts;
+  return { contacts, nextIndex: contactIndex };
 }
 
 /**

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -8,7 +8,7 @@ import { generateZoneId } from '../../utils/zoneHelpers';
 import { OFFSET, BLOCK_SIZE, LIMITS, METADATA } from './constants';
 import { createDefaultChannel } from '../../utils/channelHelpers';
 import { log } from '../../utils/protocolLogger';
-import { NO_TX_FREQUENCY, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
+import { NO_TX_FREQUENCY, isNoTxChannel } from '../../services/validation/frequencyValidator';
 
 // --- BCD frequency and CTCSS/DCS encoding (inlined from encoding.ts) ---
 
@@ -572,8 +572,10 @@ export function encodeChannel(channel: Channel): Uint8Array {
   const rxFreqBytes = encodeBCDFrequency(channel.rxFrequency);
   data.set(rxFreqBytes, 0x10);
 
-  // TX Frequency (0x14-0x17). Use 0xFF only for RX in 87–136 MHz with Forbid TX; else encode actual TX.
-  if (isRxInNoTxBand(channel.rxFrequency) && channel.forbidTx) {
+  // TX Frequency (0x14-0x17). Use 0xFF for any receive-only (Forbid TX) channel already
+  // carrying the no-TX sentinel; else encode actual TX. Not limited to the 87-136 MHz
+  // aviation band — see isNoTxChannel().
+  if (isNoTxChannel(channel)) {
     data[0x14] = data[0x15] = data[0x16] = data[0x17] = 0xFF;
   } else {
     const txFreqBytes = encodeBCDFrequency(channel.txFrequency);

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -5,7 +5,7 @@
 
 import type { Channel, Contact, Zone, ScanList, RadioSettings, DigitalEmergency, DigitalEmergencyConfig, AnalogEmergency, QuickTextMessage, DMRRadioID, CalibrationData, RXGroup, EncryptionKey, QuickContact } from '../../models';
 import { generateZoneId } from '../../utils/zoneHelpers';
-import { OFFSET, BLOCK_SIZE, LIMITS, METADATA } from './constants';
+import { OFFSET, BLOCK_SIZE, LIMITS } from './constants';
 import { createDefaultChannel } from '../../utils/channelHelpers';
 import { log } from '../../utils/protocolLogger';
 import { NO_TX_FREQUENCY, isRxInNoTxBand } from '../../services/validation/frequencyValidator';
@@ -3464,81 +3464,69 @@ export function parseQuickContacts(
   return { contacts, nextIndex: contactIndex };
 }
 
+export interface EncodeQuickContactsBlockResult {
+  data: Uint8Array;
+  /** How many of the given contacts were actually written to this block; the rest overflow to the next block. */
+  consumed: number;
+}
+
 /**
- * Encode Talk Groups to binary format for metadata block 0x44
- * This is the reverse of parseQuickContacts()
- * 
- * @param contacts - Array of Talk Groups to encode
- * @returns Encoded data (4KB block)
+ * Encode as many Talk Groups as fit into a single 4KB block. This is the reverse of
+ * parseQuickContacts() for one block.
+ *
+ * Every Talk Groups block (0x44-0x48) gets its own 1-byte 0x00 header before its first
+ * entry — confirmed against a real OEM CPS write capture (previously this was only ever
+ * applied to block 0x44's first entry, matching how encodeQuickContacts() used to write
+ * a single block; but continuation blocks 0x45-0x48 need the same header).
+ *
+ * @param contacts - Talk Groups to encode, starting from wherever this block should begin
+ * @param metadata - This block's logical ID (0x44-0x48)
  */
-export function encodeQuickContacts(contacts: QuickContact[]): Uint8Array {
+export function encodeQuickContactsBlock(contacts: QuickContact[], metadata: number): EncodeQuickContactsBlockResult {
   const data = new Uint8Array(BLOCK_SIZE.STANDARD);
   data.fill(0x00); // Initialize entire block to 0x00
-
-  // Set metadata byte at 0xFFF to 0x44 (metadata for Talk Groups block)
-  data[OFFSET.METADATA_BYTE] = METADATA.METADATA_0x44;
-
-  // Radio requires at least one contact - if none provided, create default "All" contact
-  // This prevents the radio from crashing when the block is empty
-  const contactsToEncode = contacts.length === 0 ? [{
-    index: 1,
-    offset: 0,
-    name: 'All',
-    contactNumber: 16777215, // All Call contact number
-    callType: 0x05, // All Call (0x05)
-    hasHeader: true,
-    rawData: new Uint8Array(0),
-  }] : contacts;
-  
-  if (contacts.length === 0) {
-    log.warn('No contacts provided - creating default "All" contact to prevent radio crash', 'Structures');
-  }
+  data[OFFSET.METADATA_BYTE] = metadata;
 
   let offset = 0;
 
-  for (let i = 0; i < contactsToEncode.length; i++) {
-    const contact = contactsToEncode[i];
-    const isFirstContact = i === 0;
+  // Every block's first entry is preceded by a 1-byte 0x00 header.
+  data[offset] = 0x00;
+  offset += 1;
 
-    // Contact 1 ALWAYS has 1-byte header (0x00) - this is critical for the radio to recognize the block
-    if (isFirstContact) {
-      if (offset + 1 > data.length) {
-        log.warn(`Not enough space for contact ${contact.index} header, truncating`, 'Structures');
-        break;
-      }
-      data[offset] = 0x00;
-      offset += 1;
-    }
+  let consumed = 0;
+  const metadataOffset = OFFSET.METADATA_BYTE;
 
-    // Structure: [header?] [flag] [16 name] [1 null] [3 contact] [1 call] [2 pad]
-    // Entry 1: 1 (header) + 1 (flag) + 16 (name) + 1 (null) + 3 (contact) + 1 (call) + 2 (pad) = 25 bytes
-    // Entry 2+: 1 (flag) + 16 (name) + 1 (null) + 3 (contact) + 1 (call) + 2 (pad) = 24 bytes
-    const requiredSpace = isFirstContact ? 25 : 24; // Entry 1 includes 1-byte header + flag
-    
-    if (offset + requiredSpace > data.length) {
-      log.warn(`Not enough space for contact ${contact.index}, truncating at offset ${offset}`, 'Structures');
+  for (const contact of contacts) {
+    const requiredSpace = 24; // flag(1) + name(16) + null(1) + contact(3) + call(1) + pad(2)
+
+    // Leave room for the block metadata byte at the very end (0xFFF) — entries must
+    // never spill into it.
+    if (offset + requiredSpace > metadataOffset) {
       break;
     }
 
     // Write flag byte (0x00 for PC-created contacts)
-    // Note: Radio-created contacts may have 0x01, but we write 0x00
     data[offset] = 0x00;
     offset++;
 
-    // Write name (16 bytes, null-padded)
-    // Clean the name: remove any non-ASCII printable characters (including ÿ from old parsing)
+    // Write name (16 bytes, null-padded). Names are windows-1252/Latin-1, not strict
+    // ASCII — the radio's own OEM CPS writes accented characters (e.g. "Perú", "Türkiye")
+    // as single high bytes (0xFA, 0xFC, ...), and the read side already decodes them
+    // correctly via TextDecoder('ascii'), which WHATWG aliases to windows-1252. Filtering
+    // to 0x20-0x7E and UTF-8-encoding with TextEncoder (both as this used to do) would
+    // silently drop those characters and multi-byte-encode any that survived — verified
+    // against a real OEM CPS write capture, which round-trips them as single bytes.
     const cleanName = contact.name
       .split('')
       .filter(char => {
         const code = char.charCodeAt(0);
-        return code >= 0x20 && code <= 0x7E; // Only ASCII printable characters
+        return code >= 0x20 && code <= 0xFE && code !== 0x7F; // Printable, excluding DEL and the 0xFF terminator/padding marker
       })
       .join('')
       .substring(0, 16); // Limit to 16 bytes
-    
-    const nameBytes = new TextEncoder().encode(cleanName);
+
     for (let j = 0; j < 16; j++) {
-      data[offset] = j < nameBytes.length ? nameBytes[j] : 0x00;
+      data[offset] = j < cleanName.length ? (cleanName.charCodeAt(j) & 0xFF) : 0x00;
       offset++;
     }
 
@@ -3547,12 +3535,10 @@ export function encodeQuickContacts(contacts: QuickContact[]): Uint8Array {
     offset++;
 
     // Write contact number (3 bytes, little-endian)
-    // Example: 3023401 (0x002E2229) should be written as: 29 22 2E
-    // Example: 1 (0x00000001) should be written as: 01 00 00
     const contactNumber = contact.contactNumber;
-    data[offset] = (contactNumber & 0xFF);                    // Low byte (bits 0-7)
-    data[offset + 1] = ((contactNumber >> 8) & 0xFF);         // Mid byte (bits 8-15)
-    data[offset + 2] = ((contactNumber >> 16) & 0xFF);        // High byte (bits 16-23)
+    data[offset] = (contactNumber & 0xFF);
+    data[offset + 1] = ((contactNumber >> 8) & 0xFF);
+    data[offset + 2] = ((contactNumber >> 16) & 0xFF);
     offset += 3;
 
     // Write call type (1 byte) - immediately after contact number (no padding)
@@ -3563,52 +3549,59 @@ export function encodeQuickContacts(contacts: QuickContact[]): Uint8Array {
     data[offset] = 0x00;
     data[offset + 1] = 0x00;
     offset += 2;
+
+    consumed++;
   }
 
-  // Add sentinel entry after the last contact to mark the end
-  // Sentinel: [1 flag (0x00)] [16 name (all 0x00)] [1 null] [3 contact (all 0x00)] [1 call (0x00)] [2 pad (all 0x00)]
-  if (offset + 24 <= data.length) {
-    // Flag byte
-    data[offset] = 0x00;
-    offset++;
-    
-    // 16-byte name field (all zeros)
-    for (let j = 0; j < 16; j++) {
-      data[offset] = 0x00;
-      offset++;
-    }
-    
-    // Null terminator
-    data[offset] = 0x00;
-    offset++;
-    
-    // 3 bytes contact number (all 0x00)
-    for (let j = 0; j < 3; j++) {
-      data[offset] = 0x00;
-      offset++;
-    }
-    
-    // 1 byte call type (0x00)
-    data[offset] = 0x00;
-    offset++;
-    
-    // 2 bytes padding
-    data[offset] = 0x00;
-    data[offset + 1] = 0x00;
-    offset += 2;
+  // Everything from here to the metadata byte is already 0x00 from the initial fill.
+
+  return { data, consumed };
+}
+
+/**
+ * Encode Talk Groups across as many 4KB blocks as needed (metadata 0x44, then 0x45-0x48
+ * for overflow). Mirrors parseQuickContacts()'s multi-block reading.
+ *
+ * @param contacts - Full list of Talk Groups to encode
+ * @param metadataIds - Block metadata IDs to fill, in order (e.g. [0x44, 0x45, 0x46, 0x47, 0x48])
+ * @throws if contacts don't fit in the given number of blocks
+ */
+export function encodeQuickContactsBlocks(contacts: QuickContact[], metadataIds: number[]): Uint8Array[] {
+  // Radio requires at least one contact - if none provided, create default "All" contact
+  // to prevent the radio from crashing when the block is empty.
+  const contactsToEncode = contacts.length === 0 ? [{
+    index: 1,
+    offset: 0,
+    name: 'All',
+    contactNumber: 16777215, // All Call contact number
+    callType: 0x05, // All Call (0x05)
+    hasHeader: true,
+    flag: 0,
+    rawData: new Uint8Array(0),
+  }] : contacts;
+
+  if (contacts.length === 0) {
+    log.warn('No contacts provided - creating default "All" contact to prevent radio crash', 'Structures');
   }
 
-  // Fill all remaining bytes from after termination to 0xFFF with 0x00
-  // (0xFFF is the metadata byte, which we already set to 0x44)
-  const metadataOffset = OFFSET.METADATA_BYTE;
-  for (let j = offset; j < metadataOffset; j++) {
-    data[j] = 0x00;
+  const blocks: Uint8Array[] = [];
+  let remaining = contactsToEncode;
+
+  // Always produce one block per metadata ID, even after remaining runs out — a shorter
+  // list than last time must still overwrite whatever blocks it no longer needs (matching
+  // OEM CPS, which writes an empty-but-still-headered block 0x48 when unused), otherwise
+  // stale entries from a previous, longer write would linger in the unwritten blocks.
+  for (const metadata of metadataIds) {
+    const { data, consumed } = encodeQuickContactsBlock(remaining, metadata);
+    blocks.push(data);
+    remaining = remaining.slice(consumed);
   }
 
-  // Ensure metadata byte at 0xFFF is set to 0x44
-  data[metadataOffset] = METADATA.METADATA_0x44;
+  if (remaining.length > 0) {
+    throw new Error(`${remaining.length} talk group(s) don't fit in the available ${metadataIds.length} Talk Groups block(s)`);
+  }
 
-  return data;
+  return blocks;
 }
 
 /**

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -207,21 +207,8 @@ export function parseChannel(data: Uint8Array, channelNumber: number): Channel {
     rxFreq = 0;
   }
 
-  // TX Frequency (0x14-0x17, 4 bytes BCD). All 0xFF = no TX (aviation 87–136 MHz band).
-  let txFreq: number;
-  const txBytes = data.slice(0x14, 0x18);
-  if (txBytes.every(b => b === 0xFF)) {
-    txFreq = NO_TX_FREQUENCY;
-  } else {
-    try {
-      txFreq = decodeBCDFrequency(txBytes);
-    } catch (error) {
-      log.warn(`Failed to decode TX frequency for channel ${channelNumber}`, 'Structures', error);
-      txFreq = 0;
-    }
-  }
-
-  // Mode flags (0x18)
+  // Mode flags (0x18) — read before TX frequency below, since the TX sentinel handling
+  // needs forbidTx to decide what a blank TX field actually means.
   // Bits 7-4 (mask 0xF0): Channel Mode (0=Analog, 1=Digital, 2=Fixed Analog, 3=Fixed Digital)
   // Bit 3 (mask 0x08): Forbid TX (0=Allow, 1=Forbid)
   // Bits 2-1 (mask 0x06): Power Level (0=Low, 1=Medium, 2=High) - NOT Busy Lock!
@@ -233,7 +220,28 @@ export function parseChannel(data: Uint8Array, channelNumber: number): Channel {
 
   // Forbid TX is stored at byte 0x18, bit 3 (mask 0x08)
   const forbidTx = (modeFlags & 0x08) !== 0;
-  
+
+  // TX Frequency (0x14-0x17, 4 bytes BCD). All 0xFF = blank/no TX ever written there.
+  // OEM CPS leaves this blank both for genuinely receive-only channels (Forbid TX checked)
+  // AND for ordinary channels it just never touched (Forbid TX left unchecked) — the two
+  // look identical on the wire. Only treat it as the "no TX" sentinel when Forbid TX is
+  // actually set; otherwise a blank field on a normal channel isn't receive-only, it's
+  // just unconfigured, so default TX to match RX (simplex) — a blank field defaulting to
+  // the literal sentinel value (1666.666 MHz) would fail frequency validation and get the
+  // whole channel silently dropped on the next write.
+  let txFreq: number;
+  const txBytes = data.slice(0x14, 0x18);
+  if (txBytes.every(b => b === 0xFF)) {
+    txFreq = forbidTx ? NO_TX_FREQUENCY : rxFreq;
+  } else {
+    try {
+      txFreq = decodeBCDFrequency(txBytes);
+    } catch (error) {
+      log.warn(`Failed to decode TX frequency for channel ${channelNumber}`, 'Structures', error);
+      txFreq = 0;
+    }
+  }
+
   // Power is stored at byte 0x18, bits 2-1 (mask 0x06)
   const powerValue = (modeFlags >> 1) & 0x03;
   const power: Channel['power'] = 

--- a/src/radios/dm32uv/structures.ts
+++ b/src/radios/dm32uv/structures.ts
@@ -266,12 +266,13 @@ export function parseChannel(data: Uint8Array, channelNumber: number): Channel {
   // Bits 6-4 (mask 0x70): Unknown Setting (0-3, values ≥4 reset to 0)
   // Bit 3 (mask 0x08): Unknown
   // Bit 2 (mask 0x04): APRS Receive (0=Off, 1=On)
-  // Bits 1-0 (mask 0x03): Reserved/Unknown
+  // Bits 1-0 (mask 0x03): Unknown, but OEM CPS writes 3 here on every channel - preserve, don't zero
   const talkaroundAprs = data[0x1A];
   const forbidTalkaround = (talkaroundAprs & 0x80) !== 0;
   const unknown1A_6_4 = (talkaroundAprs >> 4) & 0x07;
   const unknown1A_3 = (talkaroundAprs & 0x08) !== 0;
   const aprsReceive = (talkaroundAprs & 0x04) !== 0;
+  const unknown1A_1_0 = talkaroundAprs & 0x03;
 
   // Emergency (0x1B)
   // Bit 7: Emergency Indicator (0=Off, 1=On)
@@ -502,6 +503,7 @@ export function parseChannel(data: Uint8Array, channelNumber: number): Channel {
     scanListId,
     forbidTalkaround,
     aprsReceive,
+    unknown1A_1_0,
     emergencyIndicator,
     emergencyAck,
     emergencySystemId,
@@ -614,7 +616,7 @@ export function encodeChannel(channel: Channel): Uint8Array {
   talkaroundAprs |= ((channel.unknown1A_6_4 & 0x07) << 4) & 0x70; // Bits 6-4
   if (channel.unknown1A_3) talkaroundAprs |= 0x08; // Bit 3
   if (channel.aprsReceive) talkaroundAprs |= 0x04; // Bit 2
-  // Bits 1-0: Reserved/Unknown (preserve original value if reading, otherwise leave as 0)
+  talkaroundAprs |= channel.unknown1A_1_0 & 0x03; // Bits 1-0: preserve (OEM CPS writes 3 here)
   data[0x1A] = talkaroundAprs;
 
   // Emergency (0x1B)

--- a/src/radios/uv5rmini/channelMapping.ts
+++ b/src/radios/uv5rmini/channelMapping.ts
@@ -109,6 +109,7 @@ export function uv5rMiniRawToChannel(raw: Uv5rMiniChannelRaw): Channel {
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3,
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,

--- a/src/services/brandmeisterApi.ts
+++ b/src/services/brandmeisterApi.ts
@@ -1,0 +1,63 @@
+/**
+ * BrandMeister "Halligan" API client — read-only, unauthenticated endpoints only.
+ * Spec: https://api.brandmeister.network/api-docs (OpenAPI 3.0, "Halligan API").
+ *
+ * Only covers static talk groups for a repeater and talk group name lookup — the pieces
+ * needed to import a repeater's static talk group list into the MMDVM/repeater channel
+ * builder. Both endpoints used here are public GETs with no security requirement in the
+ * spec (only write operations like POST /device/{id}/talkgroup require an API key).
+ */
+
+const BASE_URL = 'https://api.brandmeister.network/v2';
+
+export interface BrandmeisterStaticTalkgroup {
+  talkgroup: number;
+  slot: 1 | 2;
+}
+
+/**
+ * Fetch a repeater's static talk groups by its BrandMeister repeater/device ID (the same
+ * 6-digit ID used throughout the DMR ecosystem, e.g. RptrData.id).
+ * Returns an empty array if the repeater has none configured — that's a valid, common result.
+ */
+export async function fetchBrandmeisterStaticTalkgroups(repeaterId: number): Promise<BrandmeisterStaticTalkgroup[]> {
+  const response = await fetch(`${BASE_URL}/device/${repeaterId}/talkgroup`);
+  if (!response.ok) {
+    throw new Error(`BrandMeister API returned ${response.status} for repeater ${repeaterId}`);
+  }
+  const data: Array<{ talkgroup: string | number; slot: string | number }> = await response.json();
+  return data
+    .map(entry => ({
+      talkgroup: typeof entry.talkgroup === 'string' ? parseInt(entry.talkgroup, 10) : entry.talkgroup,
+      slot: (typeof entry.slot === 'string' ? parseInt(entry.slot, 10) : entry.slot) as 1 | 2,
+    }))
+    .filter(entry => !isNaN(entry.talkgroup) && (entry.slot === 1 || entry.slot === 2));
+}
+
+/** In-memory cache — the same talk group (e.g. 3100 "USA Bridge") comes up across many repeaters. */
+const talkgroupNameCache = new Map<number, string | null>();
+
+/**
+ * Look up a talk group's display name (e.g. 3100 -> "USA Bridge"). Returns null if the
+ * lookup fails or the talk group isn't in BrandMeister's directory — callers should fall
+ * back to a generic "TG <id>" label rather than surfacing an error for this.
+ */
+export async function fetchBrandmeisterTalkgroupName(talkgroupId: number): Promise<string | null> {
+  if (talkgroupNameCache.has(talkgroupId)) {
+    return talkgroupNameCache.get(talkgroupId)!;
+  }
+  try {
+    const response = await fetch(`${BASE_URL}/talkgroup/${talkgroupId}`);
+    if (!response.ok) {
+      talkgroupNameCache.set(talkgroupId, null);
+      return null;
+    }
+    const data: { ID?: number; Name?: string } = await response.json();
+    const name = data.Name ?? null;
+    talkgroupNameCache.set(talkgroupId, name);
+    return name;
+  } catch {
+    talkgroupNameCache.set(talkgroupId, null);
+    return null;
+  }
+}

--- a/src/services/channelMerger.ts
+++ b/src/services/channelMerger.ts
@@ -62,7 +62,13 @@ export function mergeOverlappingChannels(
   // Process all channels from all sets
   for (const channelSet of channelSets) {
     for (const channel of channelSet) {
-      const freqKey = `${channel.rxFrequency.toFixed(4)}-${channel.txFrequency.toFixed(4)}`;
+      // Digital channels commonly share an RX/TX pair on purpose — multiple talk groups
+      // or timeslots on the same repeater/hotspot frequency are distinct channels, not
+      // duplicates. Only collapse them if color code, slot, and talk group also match;
+      // analog channels keep the plain frequency-only key (e.g. FRS/GMRS overlap merging).
+      const freqKey = channel.mode === 'Digital' || channel.mode === 'Fixed Digital'
+        ? `${channel.rxFrequency.toFixed(4)}-${channel.txFrequency.toFixed(4)}-${channel.colorCode}-${channel.slotOperation ?? 0}-${channel.contactId}`
+        : `${channel.rxFrequency.toFixed(4)}-${channel.txFrequency.toFixed(4)}`;
 
       if (frequencyMap.has(freqKey)) {
         // Channel with same frequencies exists - merge them

--- a/src/services/csv/csvExporter.ts
+++ b/src/services/csv/csvExporter.ts
@@ -1,5 +1,12 @@
-import type { Channel, Contact } from '../../models';
+import type { Channel, Contact, Zone, ScanList, RXGroup, DMRRadioID } from '../../models';
 import { downloadFile } from '../../utils/download';
+
+function toCSV(headers: string[], rows: (string | number)[][]): string {
+  return [
+    headers.join(','),
+    ...rows.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+  ].join('\n');
+}
 
 export function exportChannelsToCSV(channels: Channel[]): string {
   const headers = [
@@ -78,30 +85,92 @@ export function exportChannelsToCSV(channels: Channel[]): string {
     channel.contactId.toString(),
   ]);
 
-  const csvContent = [
-    headers.join(','),
-    ...rows.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
-  ].join('\n');
-
-  return csvContent;
+  return toCSV(headers, rows);
 }
 
 export function exportContactsToCSV(contacts: Contact[]): string {
-  const headers = ['ID', 'Name', 'DMR ID', 'Call Sign'];
+  const headers = ['ID', 'Name', 'DMR ID', 'Call Sign', 'City', 'Province', 'Country', 'Remark'];
 
   const rows = contacts.map(contact => [
     contact.id.toString(),
     contact.name,
     contact.dmrId.toString(),
     contact.callSign || '',
+    contact.city || '',
+    contact.province || '',
+    contact.country || '',
+    contact.remark || '',
   ]);
 
-  const csvContent = [
-    headers.join(','),
-    ...rows.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
-  ].join('\n');
+  return toCSV(headers, rows);
+}
 
-  return csvContent;
+/** Channel numbers are joined with ';' within a single cell since Zone/ScanList each hold a list. */
+const CHANNEL_LIST_SEPARATOR = ';';
+
+export function exportZonesToCSV(zones: Zone[]): string {
+  const headers = ['Zone Name', 'Channels'];
+
+  const rows = zones.map(zone => [
+    zone.name,
+    zone.channels.join(CHANNEL_LIST_SEPARATOR),
+  ]);
+
+  return toCSV(headers, rows);
+}
+
+export function exportScanListsToCSV(scanLists: ScanList[]): string {
+  const headers = [
+    'Name',
+    'Channels',
+    'CTC Scan Mode',
+    'Scan TX Mode',
+    'Hang Time',
+    'Priority 1 Type',
+    'Priority 2 Type',
+    'Priority Channel 1',
+    'Priority Channel 2',
+    'Designated TX Channel',
+  ];
+
+  const rows = scanLists.map(scanList => [
+    scanList.name,
+    scanList.channels.join(CHANNEL_LIST_SEPARATOR),
+    scanList.ctcScanMode.toString(),
+    scanList.scanTxMode.toString(),
+    scanList.hangTime?.toString() ?? '',
+    scanList.priority1Type?.toString() ?? '',
+    scanList.priority2Type?.toString() ?? '',
+    scanList.priorityChannel1?.toString() ?? '',
+    scanList.priorityChannel2?.toString() ?? '',
+    scanList.designatedTxChannel?.toString() ?? '',
+  ]);
+
+  return toCSV(headers, rows);
+}
+
+export function exportRXGroupsToCSV(groups: RXGroup[]): string {
+  const headers = ['Index', 'Name', 'Talk Group DMR IDs'];
+
+  const rows = groups.map(group => [
+    group.index.toString(),
+    group.name,
+    group.talkGroupIndices.join(CHANNEL_LIST_SEPARATOR),
+  ]);
+
+  return toCSV(headers, rows);
+}
+
+export function exportDMRRadioIDsToCSV(radioIds: DMRRadioID[]): string {
+  const headers = ['Index', 'DMR ID', 'Name'];
+
+  const rows = radioIds.map(radioId => [
+    radioId.index.toString(),
+    radioId.dmrId,
+    radioId.name,
+  ]);
+
+  return toCSV(headers, rows);
 }
 
 export function downloadCSV(content: string, filename: string): void {

--- a/src/services/csv/csvExporter.ts
+++ b/src/services/csv/csvExporter.ts
@@ -1,4 +1,4 @@
-import type { Channel, Contact, Zone, ScanList, RXGroup, DMRRadioID } from '../../models';
+import type { Channel, Contact, Zone, ScanList, RXGroup, DMRRadioID, QuickContact } from '../../models';
 import { downloadFile } from '../../utils/download';
 
 function toCSV(headers: string[], rows: (string | number)[][]): string {
@@ -168,6 +168,21 @@ export function exportDMRRadioIDsToCSV(radioIds: DMRRadioID[]): string {
     radioId.index.toString(),
     radioId.dmrId,
     radioId.name,
+  ]);
+
+  return toCSV(headers, rows);
+}
+
+const QUICK_CONTACT_CALL_TYPE_LABELS: Record<number, string> = { 0x03: 'Private', 0x04: 'Group', 0x05: 'All' };
+
+export function exportQuickContactsToCSV(contacts: QuickContact[]): string {
+  const headers = ['Index', 'Name', 'Contact Number', 'Call Type'];
+
+  const rows = contacts.map(contact => [
+    contact.index.toString(),
+    contact.name,
+    contact.contactNumber.toString(),
+    QUICK_CONTACT_CALL_TYPE_LABELS[contact.callType] ?? contact.callType.toString(),
   ]);
 
   return toCSV(headers, rows);

--- a/src/services/csv/csvImporter.ts
+++ b/src/services/csv/csvImporter.ts
@@ -1,4 +1,4 @@
-import type { Channel, Contact, Zone, ScanList, RXGroup, DMRRadioID } from '../../models';
+import type { Channel, Contact, Zone, ScanList, RXGroup, DMRRadioID, QuickContact } from '../../models';
 import { generateZoneId } from '../../utils/zoneHelpers';
 
 export interface ImportResult {
@@ -9,6 +9,7 @@ export interface ImportResult {
   scanLists?: ScanList[];
   rxGroups?: RXGroup[];
   dmrRadioIds?: DMRRadioID[];
+  quickContacts?: QuickContact[];
   errors?: string[];
 }
 
@@ -387,6 +388,58 @@ export function importDMRRadioIDsFromCSV(content: string): ImportResult {
     return {
       success: errors.length === 0,
       dmrRadioIds,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error instanceof Error ? error.message : 'Failed to parse CSV'],
+    };
+  }
+}
+
+function callTypeFromLabel(value: string): number {
+  const v = value.trim().toLowerCase();
+  if (v === 'all' || v === '0x05' || v === '5') return 0x05;
+  if (v === 'private' || v === 'prv' || v === '0x03' || v === '3') return 0x03;
+  return 0x04; // Group (default)
+}
+
+export function importQuickContactsFromCSV(content: string): ImportResult {
+  try {
+    const rows = parseCSV(content);
+    if (rows.length < 2) {
+      return { success: false, errors: ['CSV file must have at least a header row and one data row'] };
+    }
+
+    const headers = rows[0].map(h => h.toLowerCase().trim());
+    const quickContacts: QuickContact[] = [];
+    const errors: string[] = [];
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (row.length === 0 || row.every(cell => !cell.trim())) continue;
+
+      try {
+        const newIndex = quickContacts.length + 1;
+        quickContacts.push({
+          index: newIndex,
+          offset: 0,
+          name: getValue(headers, row, 'name') || `TG ${newIndex}`,
+          contactNumber: getInt(headers, row, 'contact number', 0),
+          callType: callTypeFromLabel(getValue(headers, row, 'call type')),
+          hasHeader: newIndex === 1,
+          flag: 0,
+          rawData: new Uint8Array(0),
+        });
+      } catch (error) {
+        errors.push(`Row ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      quickContacts,
       errors: errors.length > 0 ? errors : undefined,
     };
   } catch (error) {

--- a/src/services/csv/csvImporter.ts
+++ b/src/services/csv/csvImporter.ts
@@ -94,6 +94,7 @@ export function importChannelsFromCSV(content: string): ImportResult {
           unknown1A_6_4: getFloat(headers, row, 'unknown1a_6_4', 0),
           unknown1A_3: getBool(headers, row, 'unknown1a_3'),
           aprsReceive: getBool(headers, row, 'aprs receive'),
+          unknown1A_1_0: getFloat(headers, row, 'unknown1a_1_0', 3),
           emergencyIndicator: getBool(headers, row, 'emergency'),
           emergencyAck: getBool(headers, row, 'emergency ack'),
           emergencySystemId: getFloat(headers, row, 'emergency id', 0),

--- a/src/services/csv/csvImporter.ts
+++ b/src/services/csv/csvImporter.ts
@@ -1,10 +1,25 @@
-import type { Channel, Contact } from '../../models';
+import type { Channel, Contact, Zone, ScanList, RXGroup, DMRRadioID } from '../../models';
+import { generateZoneId } from '../../utils/zoneHelpers';
 
 export interface ImportResult {
   success: boolean;
   channels?: Channel[];
   contacts?: Contact[];
+  zones?: Zone[];
+  scanLists?: ScanList[];
+  rxGroups?: RXGroup[];
+  dmrRadioIds?: DMRRadioID[];
   errors?: string[];
+}
+
+/** Matches the ';' separator exportZonesToCSV/exportScanListsToCSV/exportRXGroupsToCSV use for a channel/ID list in one cell. */
+function parseNumberList(value: string): number[] {
+  return value
+    .split(';')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+    .map(s => parseInt(s, 10))
+    .filter(n => !isNaN(n));
 }
 
 export function parseCSV(content: string): string[][] {
@@ -174,6 +189,10 @@ export function importContactsFromCSV(content: string): ImportResult {
           name: getValue(headers, row, 'name') || `Contact ${i}`,
           dmrId: getInt(headers, row, 'dmr id', 0),
           callSign: getValue(headers, row, 'call sign') || undefined,
+          city: getValue(headers, row, 'city') || undefined,
+          province: getValue(headers, row, 'province') || undefined,
+          country: getValue(headers, row, 'country') || undefined,
+          remark: getValue(headers, row, 'remark') || undefined,
         };
 
         contacts.push(contact);
@@ -185,6 +204,189 @@ export function importContactsFromCSV(content: string): ImportResult {
     return {
       success: errors.length === 0,
       contacts,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error instanceof Error ? error.message : 'Failed to parse CSV'],
+    };
+  }
+}
+
+export function importZonesFromCSV(content: string): ImportResult {
+  try {
+    const rows = parseCSV(content);
+    if (rows.length < 2) {
+      return { success: false, errors: ['CSV file must have at least a header row and one data row'] };
+    }
+
+    const headers = rows[0].map(h => h.toLowerCase().trim());
+    const zones: Zone[] = [];
+    const errors: string[] = [];
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (row.length === 0 || row.every(cell => !cell.trim())) continue;
+
+      try {
+        zones.push({
+          id: generateZoneId(),
+          name: getValue(headers, row, 'zone name') || `Zone ${i}`,
+          channels: parseNumberList(getValue(headers, row, 'channels')),
+        });
+      } catch (error) {
+        errors.push(`Row ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      zones,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error instanceof Error ? error.message : 'Failed to parse CSV'],
+    };
+  }
+}
+
+export function importScanListsFromCSV(content: string): ImportResult {
+  try {
+    const rows = parseCSV(content);
+    if (rows.length < 2) {
+      return { success: false, errors: ['CSV file must have at least a header row and one data row'] };
+    }
+
+    const headers = rows[0].map(h => h.toLowerCase().trim());
+    const scanLists: ScanList[] = [];
+    const errors: string[] = [];
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (row.length === 0 || row.every(cell => !cell.trim())) continue;
+
+      try {
+        const priorityChannel1 = getValue(headers, row, 'priority channel 1');
+        const priorityChannel2 = getValue(headers, row, 'priority channel 2');
+        const designatedTxChannel = getValue(headers, row, 'designated tx channel');
+        const priority1Type = getValue(headers, row, 'priority 1 type');
+        const priority2Type = getValue(headers, row, 'priority 2 type');
+        const hangTime = getValue(headers, row, 'hang time');
+
+        scanLists.push({
+          name: getValue(headers, row, 'name') || `Scan List ${i}`,
+          channels: parseNumberList(getValue(headers, row, 'channels')),
+          ctcScanMode: getInt(headers, row, 'ctc scan mode', 0),
+          scanTxMode: getInt(headers, row, 'scan tx mode', 0),
+          hangTime: hangTime === '' ? undefined : parseInt(hangTime, 10),
+          priority1Type: priority1Type === '' ? undefined : parseInt(priority1Type, 10),
+          priority2Type: priority2Type === '' ? undefined : parseInt(priority2Type, 10),
+          priorityChannel1: priorityChannel1 === '' ? undefined : parseInt(priorityChannel1, 10),
+          priorityChannel2: priorityChannel2 === '' ? undefined : parseInt(priorityChannel2, 10),
+          designatedTxChannel: designatedTxChannel === '' ? undefined : parseInt(designatedTxChannel, 10),
+        });
+      } catch (error) {
+        errors.push(`Row ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      scanLists,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error instanceof Error ? error.message : 'Failed to parse CSV'],
+    };
+  }
+}
+
+export function importRXGroupsFromCSV(content: string): ImportResult {
+  try {
+    const rows = parseCSV(content);
+    if (rows.length < 2) {
+      return { success: false, errors: ['CSV file must have at least a header row and one data row'] };
+    }
+
+    const headers = rows[0].map(h => h.toLowerCase().trim());
+    const rxGroups: RXGroup[] = [];
+    const errors: string[] = [];
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (row.length === 0 || row.every(cell => !cell.trim())) continue;
+
+      try {
+        rxGroups.push({
+          index: getInt(headers, row, 'index', 0) || (i - 1),
+          name: getValue(headers, row, 'name') || `RX Group ${i}`,
+          bitmask: 0, // Derived at encode time from the group's position, not stored per-entry
+          statusFlag: 0,
+          entryFlag: 1,
+          validationFlag: 0,
+          talkGroupIndices: parseNumberList(getValue(headers, row, 'talk group dmr ids')),
+        });
+      } catch (error) {
+        errors.push(`Row ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      rxGroups,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error instanceof Error ? error.message : 'Failed to parse CSV'],
+    };
+  }
+}
+
+export function importDMRRadioIDsFromCSV(content: string): ImportResult {
+  try {
+    const rows = parseCSV(content);
+    if (rows.length < 2) {
+      return { success: false, errors: ['CSV file must have at least a header row and one data row'] };
+    }
+
+    const headers = rows[0].map(h => h.toLowerCase().trim());
+    const dmrRadioIds: DMRRadioID[] = [];
+    const errors: string[] = [];
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (row.length === 0 || row.every(cell => !cell.trim())) continue;
+
+      try {
+        const dmrId = getValue(headers, row, 'dmr id') || '0';
+        const dmrIdValue = parseInt(dmrId, 10) || 0;
+        const bytes = new Uint8Array(3);
+        bytes[0] = dmrIdValue & 0xFF;
+        bytes[1] = (dmrIdValue >> 8) & 0xFF;
+        bytes[2] = (dmrIdValue >> 16) & 0xFF;
+
+        dmrRadioIds.push({
+          index: getInt(headers, row, 'index', 0) || (i - 1),
+          dmrId,
+          dmrIdValue,
+          dmrIdBytes: bytes,
+          name: getValue(headers, row, 'name') || `Radio ID ${i}`,
+        });
+      } catch (error) {
+        errors.push(`Row ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      dmrRadioIds,
       errors: errors.length > 0 ? errors : undefined,
     };
   } catch (error) {

--- a/src/services/mmdvmChannels.ts
+++ b/src/services/mmdvmChannels.ts
@@ -1,13 +1,13 @@
 /**
  * MMDVM Channel Generator
- * Creates digital channels and talk groups for an MMDVM hotspot — either simplex
- * (single frequency, the common case) or duplex (separate RX/TX, for a hotspot
- * linked to a real repeater pair on 2m or 70cm). Color Code 1, user-defined talk groups.
+ * Creates digital channels for an MMDVM hotspot — either simplex (single frequency, the
+ * common case) or duplex (separate RX/TX, for a hotspot linked to a real repeater pair on
+ * 2m or 70cm). Color Code 1. Talk groups are resolved by the caller against the Talk Groups
+ * (QuickContact) list before calling this — this function only builds channels.
  */
 
-import type { Channel, Contact, Zone } from '../models';
+import type { Channel } from '../models';
 import { createDefaultChannel } from '../utils/channelHelpers';
-import { generateZoneId } from '../utils/zoneHelpers';
 
 export const MMDVM_FREQ_MIN_MHZ = 431;
 export const MMDVM_FREQ_MAX_MHZ = 435;
@@ -28,8 +28,10 @@ export const MMDVM_DUPLEX_RANGE_DESCRIPTION =
 
 export interface MMDVMChannelEntry {
   channelName: string;
-  talkGroupName: string;
-  talkGroupId: number; // DMR talk group number (e.g. 9 for local, 3100 for BM Canada)
+  /** Index into the Talk Groups (QuickContact) list — what the channel actually references
+   *  for TX. Resolve this against an existing talk group or a newly-created one before
+   *  calling generateMMDVMChannels(); 0 = None. */
+  contactId: number;
 }
 
 export interface MMDVMGenerateOptions {
@@ -38,17 +40,13 @@ export interface MMDVMGenerateOptions {
   txFrequencyMhz?: number;
   entries: MMDVMChannelEntry[];
   firstChannelNumber: number;
-  firstContactId: number; // Next available contact id (e.g. max(existing contact ids) + 1)
   dmrRadioIdIndex: number | undefined; // 0-based index into DMR Radio IDs; undefined = None
-  zoneName?: string;
   /** 1 = TS1, 2 = TS2. Defaults to TS2 (the usual MMDVM hotspot convention). */
   timeslot?: 1 | 2;
 }
 
 export interface MMDVMGenerateResult {
   channels: Channel[];
-  contacts: Contact[];
-  zone: Zone;
 }
 
 /**
@@ -70,15 +68,14 @@ export function isValidMMDVMDuplexFrequency(mhz: number): boolean {
 }
 
 /**
- * Generate MMDVM channels and talk group contacts, simplex or duplex.
- * Same RX/TX pair for all channels; Slot 2, Color Code 1; each channel gets its own talk group.
+ * Generate MMDVM channels, simplex or duplex. Same RX/TX pair for all channels, Color Code 1.
  */
 export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGenerateResult {
-  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, firstContactId, dmrRadioIdIndex, zoneName, timeslot } = options;
+  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, dmrRadioIdIndex, timeslot } = options;
 
   // The narrow 431-435 MHz range is a simplex-hotspot calling-frequency convention — it
   // doesn't apply to duplex, where RX mirrors the hotspot's own transmit-to-repeater
-  // frequency and can be anywhere in the 70cm band, same as TX.
+  // frequency and can be anywhere in the 2m/70cm band, same as TX.
   const isDuplex = txFrequencyMhz !== undefined && txFrequencyMhz !== frequencyMhz;
   if (isDuplex) {
     if (!isValidMMDVMDuplexFrequency(frequencyMhz)) {
@@ -93,46 +90,23 @@ export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGener
   const txFreq = txFrequencyMhz ?? frequencyMhz;
   const slotOperation = timeslot === 1 ? 0 : 1; // Storage: 0 = TS1, 1 = TS2
   if (!entries.length) {
-    throw new Error('At least one channel/talk group entry is required');
+    throw new Error('At least one channel entry is required');
   }
 
-  const contacts: Contact[] = [];
-  const channels: Channel[] = [];
-  let nextContactId = firstContactId;
+  const channels: Channel[] = entries.map((entry, i) => createDefaultChannel({
+    number: firstChannelNumber + i,
+    name: (entry.channelName || `MMDVM ${i + 1}`).substring(0, 16),
+    rxFrequency: frequencyMhz,
+    txFrequency: txFreq,
+    mode: 'Digital',
+    bandwidth: '12.5kHz',
+    power: 'Low',
+    scanAdd: true,
+    colorCode: 1,
+    contactId: entry.contactId,
+    slotOperation,
+    dmrRadioIdIndex,
+  }));
 
-  for (let i = 0; i < entries.length; i++) {
-    const entry = entries[i];
-    const contactId = nextContactId++;
-    const contact: Contact = {
-      id: contactId,
-      name: (entry.talkGroupName || `TG ${entry.talkGroupId}`).substring(0, 16),
-      dmrId: entry.talkGroupId,
-    };
-    contacts.push(contact);
-
-    const channelName = (entry.channelName || entry.talkGroupName || `MMDVM ${i + 1}`).substring(0, 16);
-    const ch = createDefaultChannel({
-      number: firstChannelNumber + i,
-      name: channelName,
-      rxFrequency: frequencyMhz,
-      txFrequency: txFreq,
-      mode: 'Digital',
-      bandwidth: '12.5kHz',
-      power: 'Low',
-      scanAdd: true,
-      colorCode: 1,
-      contactId,
-      slotOperation,
-      dmrRadioIdIndex,
-    });
-    channels.push(ch);
-  }
-
-  const zone: Zone = {
-    id: generateZoneId(),
-    name: (zoneName || 'MMDVM').substring(0, 16),
-    channels: channels.map((c) => c.number),
-  };
-
-  return { channels, contacts, zone };
+  return { channels };
 }

--- a/src/services/mmdvmChannels.ts
+++ b/src/services/mmdvmChannels.ts
@@ -2,7 +2,7 @@
  * MMDVM Channel Generator
  * Creates digital channels and talk groups for an MMDVM hotspot — either simplex
  * (single frequency, the common case) or duplex (separate RX/TX, for a hotspot
- * linked to a real UHF repeater pair). Slot 2, Color Code 1, user-defined talk groups.
+ * linked to a real repeater pair on 2m or 70cm). Color Code 1, user-defined talk groups.
  */
 
 import type { Channel, Contact, Zone } from '../models';
@@ -13,11 +13,18 @@ export const MMDVM_FREQ_MIN_MHZ = 431;
 export const MMDVM_FREQ_MAX_MHZ = 435;
 
 /**
- * A duplex hotspot's TX pairs with a real repeater, which can sit anywhere in the 70cm
- * ham band — not just the narrow 431-435 MHz simplex-hotspot calling range above.
+ * A duplex hotspot's RX/TX pair with a real repeater, which can sit anywhere in the 2m or
+ * 70cm ham band depending on the hotspot's radio module — not just the narrow 431-435 MHz
+ * simplex-hotspot calling range above. Applies to BOTH frequencies in duplex mode, not just
+ * TX: the radio's RX mirrors the hotspot's own transmit-to-repeater frequency, which is just
+ * as unconstrained as the TX side.
  */
-export const MMDVM_DUPLEX_TX_MIN_MHZ = 400;
-export const MMDVM_DUPLEX_TX_MAX_MHZ = 480;
+export const MMDVM_DUPLEX_VHF_MIN_MHZ = 136;
+export const MMDVM_DUPLEX_VHF_MAX_MHZ = 174;
+export const MMDVM_DUPLEX_UHF_MIN_MHZ = 400;
+export const MMDVM_DUPLEX_UHF_MAX_MHZ = 480;
+export const MMDVM_DUPLEX_RANGE_DESCRIPTION =
+  `${MMDVM_DUPLEX_VHF_MIN_MHZ}-${MMDVM_DUPLEX_VHF_MAX_MHZ} MHz (2m) or ${MMDVM_DUPLEX_UHF_MIN_MHZ}-${MMDVM_DUPLEX_UHF_MAX_MHZ} MHz (70cm)`;
 
 export interface MMDVMChannelEntry {
   channelName: string;
@@ -52,11 +59,14 @@ export function isValidMMDVMFrequency(mhz: number): boolean {
 }
 
 /**
- * Validate a duplex hotspot's TX frequency — the broader 70cm band, since it pairs
- * with a real repeater rather than another hotspot.
+ * Validate a duplex hotspot's RX or TX frequency — the broader 2m or 70cm ham band, since
+ * it pairs with a real repeater rather than another hotspot. Applies to both sides of the pair.
  */
-export function isValidMMDVMDuplexTxFrequency(mhz: number): boolean {
-  return mhz >= MMDVM_DUPLEX_TX_MIN_MHZ && mhz <= MMDVM_DUPLEX_TX_MAX_MHZ && !isNaN(mhz);
+export function isValidMMDVMDuplexFrequency(mhz: number): boolean {
+  if (isNaN(mhz)) return false;
+  const inVhf = mhz >= MMDVM_DUPLEX_VHF_MIN_MHZ && mhz <= MMDVM_DUPLEX_VHF_MAX_MHZ;
+  const inUhf = mhz >= MMDVM_DUPLEX_UHF_MIN_MHZ && mhz <= MMDVM_DUPLEX_UHF_MAX_MHZ;
+  return inVhf || inUhf;
 }
 
 /**
@@ -66,12 +76,19 @@ export function isValidMMDVMDuplexTxFrequency(mhz: number): boolean {
 export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGenerateResult {
   const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, firstContactId, dmrRadioIdIndex, zoneName, timeslot } = options;
 
-  if (!isValidMMDVMFrequency(frequencyMhz)) {
-    throw new Error(`RX frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
-  }
+  // The narrow 431-435 MHz range is a simplex-hotspot calling-frequency convention — it
+  // doesn't apply to duplex, where RX mirrors the hotspot's own transmit-to-repeater
+  // frequency and can be anywhere in the 70cm band, same as TX.
   const isDuplex = txFrequencyMhz !== undefined && txFrequencyMhz !== frequencyMhz;
-  if (isDuplex && !isValidMMDVMDuplexTxFrequency(txFrequencyMhz)) {
-    throw new Error(`TX frequency must be between ${MMDVM_DUPLEX_TX_MIN_MHZ} and ${MMDVM_DUPLEX_TX_MAX_MHZ} MHz`);
+  if (isDuplex) {
+    if (!isValidMMDVMDuplexFrequency(frequencyMhz)) {
+      throw new Error(`RX frequency must be in ${MMDVM_DUPLEX_RANGE_DESCRIPTION}`);
+    }
+    if (!isValidMMDVMDuplexFrequency(txFrequencyMhz)) {
+      throw new Error(`TX frequency must be in ${MMDVM_DUPLEX_RANGE_DESCRIPTION}`);
+    }
+  } else if (!isValidMMDVMFrequency(frequencyMhz)) {
+    throw new Error(`Frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
   }
   const txFreq = txFrequencyMhz ?? frequencyMhz;
   const slotOperation = timeslot === 1 ? 0 : 1; // Storage: 0 = TS1, 1 = TS2

--- a/src/services/mmdvmChannels.ts
+++ b/src/services/mmdvmChannels.ts
@@ -32,6 +32,10 @@ export interface MMDVMChannelEntry {
    *  for TX. Resolve this against an existing talk group or a newly-created one before
    *  calling generateMMDVMChannels(); 0 = None. */
   contactId: number;
+  /** Per-entry timeslot override (1 = TS1, 2 = TS2). Falls back to the top-level timeslot
+   *  option when unset — a real repeater commonly runs different static talk groups on
+   *  each slot, which a single hotspot-wide timeslot can't represent. */
+  timeslot?: 1 | 2;
 }
 
 export interface MMDVMGenerateOptions {
@@ -41,8 +45,11 @@ export interface MMDVMGenerateOptions {
   entries: MMDVMChannelEntry[];
   firstChannelNumber: number;
   dmrRadioIdIndex: number | undefined; // 0-based index into DMR Radio IDs; undefined = None
-  /** 1 = TS1, 2 = TS2. Defaults to TS2 (the usual MMDVM hotspot convention). */
+  /** 1 = TS1, 2 = TS2. Default for entries that don't specify their own timeslot. */
   timeslot?: 1 | 2;
+  /** DMR color code. Defaults to 1 (the usual MMDVM hotspot convention) — a real repeater
+   *  can use any value 0-15. */
+  colorCode?: number;
 }
 
 export interface MMDVMGenerateResult {
@@ -71,7 +78,7 @@ export function isValidMMDVMDuplexFrequency(mhz: number): boolean {
  * Generate MMDVM channels, simplex or duplex. Same RX/TX pair for all channels, Color Code 1.
  */
 export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGenerateResult {
-  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, dmrRadioIdIndex, timeslot } = options;
+  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, dmrRadioIdIndex, timeslot, colorCode } = options;
 
   // The narrow 431-435 MHz range is a simplex-hotspot calling-frequency convention — it
   // doesn't apply to duplex, where RX mirrors the hotspot's own transmit-to-repeater
@@ -88,7 +95,7 @@ export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGener
     throw new Error(`Frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
   }
   const txFreq = txFrequencyMhz ?? frequencyMhz;
-  const slotOperation = timeslot === 1 ? 0 : 1; // Storage: 0 = TS1, 1 = TS2
+  const defaultSlotOperation = timeslot === 1 ? 0 : 1; // Storage: 0 = TS1, 1 = TS2
   if (!entries.length) {
     throw new Error('At least one channel entry is required');
   }
@@ -102,9 +109,9 @@ export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGener
     bandwidth: '12.5kHz',
     power: 'Low',
     scanAdd: true,
-    colorCode: 1,
+    colorCode: colorCode ?? 1,
     contactId: entry.contactId,
-    slotOperation,
+    slotOperation: entry.timeslot !== undefined ? (entry.timeslot === 1 ? 0 : 1) : defaultSlotOperation,
     dmrRadioIdIndex,
   }));
 

--- a/src/services/mmdvmChannels.ts
+++ b/src/services/mmdvmChannels.ts
@@ -1,7 +1,8 @@
 /**
- * MMDVM Simplex Channel Generator
- * Creates digital channels and talk groups for a simplex MMDVM hotspot
- * (single frequency, Slot 2, Color Code 1, user-defined talk groups).
+ * MMDVM Channel Generator
+ * Creates digital channels and talk groups for an MMDVM hotspot — either simplex
+ * (single frequency, the common case) or duplex (separate RX/TX, for a hotspot
+ * linked to a real UHF repeater pair). Slot 2, Color Code 1, user-defined talk groups.
  */
 
 import type { Channel, Contact, Zone } from '../models';
@@ -11,6 +12,13 @@ import { generateZoneId } from '../utils/zoneHelpers';
 export const MMDVM_FREQ_MIN_MHZ = 431;
 export const MMDVM_FREQ_MAX_MHZ = 435;
 
+/**
+ * A duplex hotspot's TX pairs with a real repeater, which can sit anywhere in the 70cm
+ * ham band — not just the narrow 431-435 MHz simplex-hotspot calling range above.
+ */
+export const MMDVM_DUPLEX_TX_MIN_MHZ = 400;
+export const MMDVM_DUPLEX_TX_MAX_MHZ = 480;
+
 export interface MMDVMChannelEntry {
   channelName: string;
   talkGroupName: string;
@@ -18,7 +26,9 @@ export interface MMDVMChannelEntry {
 }
 
 export interface MMDVMGenerateOptions {
-  frequencyMhz: number;
+  frequencyMhz: number; // RX frequency
+  /** TX frequency for a duplex hotspot; omit (or equal to frequencyMhz) for simplex. */
+  txFrequencyMhz?: number;
   entries: MMDVMChannelEntry[];
   firstChannelNumber: number;
   firstContactId: number; // Next available contact id (e.g. max(existing contact ids) + 1)
@@ -40,15 +50,28 @@ export function isValidMMDVMFrequency(mhz: number): boolean {
 }
 
 /**
- * Generate MMDVM simplex channels and talk group contacts.
- * Same frequency for all channels; Slot 2, Color Code 1; each channel gets its own talk group.
+ * Validate a duplex hotspot's TX frequency — the broader 70cm band, since it pairs
+ * with a real repeater rather than another hotspot.
+ */
+export function isValidMMDVMDuplexTxFrequency(mhz: number): boolean {
+  return mhz >= MMDVM_DUPLEX_TX_MIN_MHZ && mhz <= MMDVM_DUPLEX_TX_MAX_MHZ && !isNaN(mhz);
+}
+
+/**
+ * Generate MMDVM channels and talk group contacts, simplex or duplex.
+ * Same RX/TX pair for all channels; Slot 2, Color Code 1; each channel gets its own talk group.
  */
 export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGenerateResult {
-  const { frequencyMhz, entries, firstChannelNumber, firstContactId, dmrRadioIdIndex, zoneName } = options;
+  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, firstContactId, dmrRadioIdIndex, zoneName } = options;
 
   if (!isValidMMDVMFrequency(frequencyMhz)) {
-    throw new Error(`Frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
+    throw new Error(`RX frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
   }
+  const isDuplex = txFrequencyMhz !== undefined && txFrequencyMhz !== frequencyMhz;
+  if (isDuplex && !isValidMMDVMDuplexTxFrequency(txFrequencyMhz)) {
+    throw new Error(`TX frequency must be between ${MMDVM_DUPLEX_TX_MIN_MHZ} and ${MMDVM_DUPLEX_TX_MAX_MHZ} MHz`);
+  }
+  const txFreq = txFrequencyMhz ?? frequencyMhz;
   if (!entries.length) {
     throw new Error('At least one channel/talk group entry is required');
   }
@@ -72,7 +95,7 @@ export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGener
       number: firstChannelNumber + i,
       name: channelName,
       rxFrequency: frequencyMhz,
-      txFrequency: frequencyMhz, // Simplex: same as RX
+      txFrequency: txFreq,
       mode: 'Digital',
       bandwidth: '12.5kHz',
       power: 'Low',

--- a/src/services/mmdvmChannels.ts
+++ b/src/services/mmdvmChannels.ts
@@ -34,6 +34,8 @@ export interface MMDVMGenerateOptions {
   firstContactId: number; // Next available contact id (e.g. max(existing contact ids) + 1)
   dmrRadioIdIndex: number | undefined; // 0-based index into DMR Radio IDs; undefined = None
   zoneName?: string;
+  /** 1 = TS1, 2 = TS2. Defaults to TS2 (the usual MMDVM hotspot convention). */
+  timeslot?: 1 | 2;
 }
 
 export interface MMDVMGenerateResult {
@@ -62,7 +64,7 @@ export function isValidMMDVMDuplexTxFrequency(mhz: number): boolean {
  * Same RX/TX pair for all channels; Slot 2, Color Code 1; each channel gets its own talk group.
  */
 export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGenerateResult {
-  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, firstContactId, dmrRadioIdIndex, zoneName } = options;
+  const { frequencyMhz, txFrequencyMhz, entries, firstChannelNumber, firstContactId, dmrRadioIdIndex, zoneName, timeslot } = options;
 
   if (!isValidMMDVMFrequency(frequencyMhz)) {
     throw new Error(`RX frequency must be between ${MMDVM_FREQ_MIN_MHZ} and ${MMDVM_FREQ_MAX_MHZ} MHz`);
@@ -72,6 +74,7 @@ export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGener
     throw new Error(`TX frequency must be between ${MMDVM_DUPLEX_TX_MIN_MHZ} and ${MMDVM_DUPLEX_TX_MAX_MHZ} MHz`);
   }
   const txFreq = txFrequencyMhz ?? frequencyMhz;
+  const slotOperation = timeslot === 1 ? 0 : 1; // Storage: 0 = TS1, 1 = TS2
   if (!entries.length) {
     throw new Error('At least one channel/talk group entry is required');
   }
@@ -102,7 +105,7 @@ export function generateMMDVMChannels(options: MMDVMGenerateOptions): MMDVMGener
       scanAdd: true,
       colorCode: 1,
       contactId,
-      slotOperation: 1, // Slot 2 (TS2)
+      slotOperation,
       dmrRadioIdIndex,
     });
     channels.push(ch);

--- a/src/services/validation/channelValidator.ts
+++ b/src/services/validation/channelValidator.ts
@@ -1,6 +1,6 @@
 import type { Channel } from '../../models/Channel';
 import type { RadioBandLimits } from '../../types/radioCapabilities';
-import { isNoTxFrequency, isRxInNoTxBand } from './frequencyValidator';
+import { isNoTxChannel } from './frequencyValidator';
 import { isValidColorCode, isValidTimeSlot } from './dmrValidator';
 
 export interface ValidationError {
@@ -34,8 +34,8 @@ export function validateChannel(
   if (channel.rxFrequency <= 0) {
     errors.push({ field: 'rxFrequency', message: 'RX frequency must be greater than 0' });
   }
-  const isNoTxChannel = isRxInNoTxBand(channel.rxFrequency) && channel.forbidTx && isNoTxFrequency(channel.txFrequency);
-  if (!isNoTxChannel && channel.txFrequency <= 0) {
+  const noTxChannel = isNoTxChannel(channel);
+  if (!noTxChannel && channel.txFrequency <= 0) {
     errors.push({ field: 'txFrequency', message: 'TX frequency must be greater than 0' });
   }
 

--- a/src/services/validation/frequencyValidator.ts
+++ b/src/services/validation/frequencyValidator.ts
@@ -20,6 +20,20 @@ export function isRxInNoTxBand(rxFrequency: number): boolean {
 }
 
 /**
+ * True if this channel is receive-only with TX stored as the 0xFF sentinel.
+ *
+ * Not limited to the 87–136 MHz aviation band: real codeplugs (confirmed against OEM CPS
+ * output) use Forbid TX + the 0xFF sentinel for receive-only channels anywhere in the band
+ * (e.g. a paging monitor channel at 159 MHz), not just aviation receive. Gating this on
+ * isRxInNoTxBand() caused isValidChannelFrequency() to reject such channels outright
+ * (their leftover/sentinel TX value fails the normal band-range check), silently dropping
+ * them from writes.
+ */
+export function isNoTxChannel(channel: Channel): boolean {
+  return channel.forbidTx && isNoTxFrequency(channel.txFrequency);
+}
+
+/**
  * Check if a frequency is in the supported ranges.
  * When limits is provided (e.g. from getCapabilitiesForModel), uses those; otherwise uses default ranges.
  */
@@ -39,7 +53,7 @@ export function isValidFrequencyRange(frequency: number, limits?: RadioBandLimit
  */
 export function isValidChannelFrequency(channel: Channel, limits?: RadioBandLimits | null): boolean {
   if (channel.rxFrequency <= 0) return false;
-  if (isRxInNoTxBand(channel.rxFrequency) && channel.forbidTx && isNoTxFrequency(channel.txFrequency)) {
+  if (isNoTxChannel(channel)) {
     return isValidFrequencyRange(channel.rxFrequency, limits);
   }
   if (channel.txFrequency <= 0) return false;

--- a/src/store/channelsStore.ts
+++ b/src/store/channelsStore.ts
@@ -16,6 +16,8 @@ interface ChannelsState {
   setChannels: (channels: Channel[]) => void;
   setRawChannelData: (rawData: Map<number, RawChannelData>) => void;
   addChannel: (channel: Channel) => void;
+  /** Append multiple channels atomically against the latest state (safe against concurrent/rapid add actions) */
+  addChannels: (channels: Channel[]) => void;
   updateChannel: (number: number, channel: Partial<Channel>) => void;
   deleteChannel: (number: number) => void;
   /** Remove multiple channels at once and renumber; use for bulk delete so renumbering doesn't invalidate later numbers */
@@ -31,6 +33,9 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
   setRawChannelData: (rawData) => set({ rawChannelData: rawData }),
   addChannel: (channel) => set((state) => ({
     channels: [...state.channels, channel]
+  })),
+  addChannels: (newChannels) => set((state) => ({
+    channels: [...state.channels, ...newChannels]
   })),
   updateChannel: (number, updates) => set((state) => ({
     channels: state.channels.map(ch => 

--- a/src/store/contactsStore.ts
+++ b/src/store/contactsStore.ts
@@ -7,6 +7,8 @@ interface ContactsState {
   contactsLoaded: boolean; // Track if contacts have been read from radio
   setContacts: (contacts: Contact[]) => void;
   addContact: (contact: Contact) => void;
+  /** Append multiple contacts atomically against the latest state (safe against concurrent/rapid add actions) */
+  addContacts: (contacts: Contact[]) => void;
   updateContact: (id: number, contact: Partial<Contact>) => void;
   deleteContact: (id: number) => void;
   setSelectedContact: (id: number | null) => void;
@@ -23,6 +25,9 @@ export const useContactsStore = create<ContactsState>((set) => ({
   },
   addContact: (contact) => set((state) => ({
     contacts: [...state.contacts, contact]
+  })),
+  addContacts: (newContacts) => set((state) => ({
+    contacts: [...state.contacts, ...newContacts]
   })),
   updateContact: (id, updates) => set((state) => ({
     contacts: state.contacts.map(c => 

--- a/src/store/quickContactsStore.ts
+++ b/src/store/quickContactsStore.ts
@@ -12,6 +12,8 @@ interface QuickContactsState {
   setMaxTalkGroups: (max: number) => void;
   updateContact: (index: number, contact: Partial<QuickContact>) => void;
   addContact: (contact: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>) => void;
+  /** Append multiple talk groups atomically against the latest state (safe against concurrent/rapid add actions) */
+  addContacts: (contacts: Omit<QuickContact, 'index' | 'offset' | 'rawData' | 'hasHeader'>[]) => void;
   deleteContact: (index: number) => void;
 }
 
@@ -71,6 +73,26 @@ export const useQuickContactsStore = create<QuickContactsState>((set, get) => ({
       rawData: new Uint8Array(0), // Will be generated when writing
     };
     set({ contacts: [...contacts, contact] });
+  },
+  addContacts: (newContacts) => {
+    const { contacts, maxTalkGroups } = get();
+    const max = maxTalkGroups ?? DEFAULT_TALK_GROUPS_MAX;
+    const room = Math.max(0, max - contacts.length);
+    if (newContacts.length > room) {
+      console.warn(`Maximum of ${max} talk groups allowed — adding ${room} of ${newContacts.length} requested`);
+    }
+    const toAdd = newContacts.slice(0, room).map((newContact, i) => {
+      const newIndex = contacts.length + i + 1;
+      return {
+        ...newContact,
+        name: cleanContactName(newContact.name),
+        index: newIndex,
+        offset: 0,
+        hasHeader: newIndex === 1,
+        rawData: new Uint8Array(0),
+      };
+    });
+    set({ contacts: [...contacts, ...toAdd] });
   },
   deleteContact: (index) => {
     const contacts = get().contacts.filter(contact => contact.index !== index);

--- a/src/store/zonesStore.ts
+++ b/src/store/zonesStore.ts
@@ -14,6 +14,8 @@ interface ZonesState {
   setZones: (zones: Zone[]) => void;
   setRawZoneData: (rawData: Map<string, RawZoneData>) => void;
   addZone: (zone: Omit<Zone, 'id'>) => void;
+  /** Append multiple zones atomically against the latest state (safe against concurrent/rapid add actions) */
+  addZones: (zones: Zone[]) => void;
   updateZone: (id: string, zone: Partial<Omit<Zone, 'id'>>) => void;
   renameZone: (id: string, newName: string) => boolean;
   deleteZone: (id: string) => void;
@@ -37,6 +39,13 @@ export const useZonesStore = create<ZonesState>((set, get) => ({
     set({ zones: zonesWithIds });
   },
   setRawZoneData: (rawData) => set({ rawZoneData: rawData }),
+  addZones: (zones) => set((state) => {
+    const zonesWithIds = zones.map((z, index) => ({
+      ...z,
+      id: z.id || `zone-${Date.now()}-${index}-${Math.random().toString(36).substr(2, 9)}`
+    }));
+    return { zones: [...state.zones, ...zonesWithIds] };
+  }),
   addZone: (zone) => set((state) => {
     if (state.zones.length >= 250) {
       console.warn('Maximum of 250 zones allowed');

--- a/src/utils/channelHelpers.ts
+++ b/src/utils/channelHelpers.ts
@@ -27,6 +27,7 @@ export function createDefaultChannel(overrides: Partial<Channel> = {}): Channel 
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,

--- a/src/utils/channelHelpers.ts
+++ b/src/utils/channelHelpers.ts
@@ -4,6 +4,47 @@
 
 import type { Channel } from '../models';
 
+export interface ChannelRenumberResult {
+  /** Channels renumbered to a contiguous 1..N sequence, sorted by their prior number */
+  channels: Channel[];
+  /** Prior channel.number -> new channel.number, for remapping zone/scan-list references */
+  oldToNew: Map<number, number>;
+  /** True if any renumbering actually happened (numbers weren't already 1..N matching array order) */
+  hadGaps: boolean;
+}
+
+/**
+ * Renumber channels to a contiguous 1..N sequence matching sorted order.
+ *
+ * The radio's write path (generateChannelBlocks) packs channels back-to-back purely by
+ * array position and ignores channel.number entirely; zones and scan lists then reference
+ * channels by the raw .number value. Reading skips blank slots on the radio without
+ * reserving their number, so channel.number can come back with gaps (e.g. ...50, 52, 53...
+ * if slot 51 was blank). Left uncompacted, the next write silently shifts every channel
+ * after a gap into the wrong physical slot and any zone/scan-list referencing the old
+ * numbers ends up pointing at the wrong channel. Call this right after reading channels,
+ * and remap zone/scan-list channel references with the returned oldToNew map.
+ */
+export function compactChannelNumbers(channels: Channel[]): ChannelRenumberResult {
+  const sorted = [...channels].sort((a, b) => a.number - b.number);
+  const hadGaps = sorted.some((ch, i) => ch.number !== i + 1);
+  const oldToNew = new Map(sorted.map((ch, i) => [ch.number, i + 1]));
+  const renumbered = hadGaps ? sorted.map((ch, i) => ({ ...ch, number: i + 1 })) : sorted;
+  return { channels: renumbered, oldToNew, hadGaps };
+}
+
+/** Remap a list of channel numbers (e.g. a zone's or scan list's .channels) through an oldToNew map, dropping any that no longer exist. */
+export function remapChannelNumbers(numbers: number[], oldToNew: Map<number, number>): number[] {
+  return numbers
+    .map(n => oldToNew.get(n))
+    .filter((n): n is number => n !== undefined);
+}
+
+/** Remap a single optional channel reference (e.g. a scan list's priority/designated-TX channel) through an oldToNew map. */
+export function remapChannelNumber(n: number | undefined, oldToNew: Map<number, number>): number | undefined {
+  return n === undefined ? undefined : oldToNew.get(n);
+}
+
 /**
  * Create a new channel with sensible defaults
  * All unknown fields are set to 0/false to match typical radio defaults

--- a/src/utils/sampleData.ts
+++ b/src/utils/sampleData.ts
@@ -16,6 +16,7 @@ export const sampleChannels: Channel[] = [
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,
@@ -65,6 +66,7 @@ export const sampleChannels: Channel[] = [
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,
@@ -114,6 +116,7 @@ export const sampleChannels: Channel[] = [
     unknown1A_6_4: 0,
     unknown1A_3: false,
     aprsReceive: false,
+    unknown1A_1_0: 3, // OEM CPS writes 3 here on every channel
     emergencyIndicator: false,
     emergencyAck: false,
     emergencySystemId: 0,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,4 +2,5 @@
 
 declare const __COMMIT_HASH__: string;
 declare const __BUILD_TIME__: string;
+declare const __APP_VERSION__: string;
 

--- a/tests/unit/mmdvmChannels.test.ts
+++ b/tests/unit/mmdvmChannels.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import {
   isValidMMDVMFrequency,
+  isValidMMDVMDuplexFrequency,
   generateMMDVMChannels,
   MMDVM_FREQ_MIN_MHZ,
   MMDVM_FREQ_MAX_MHZ,
+  MMDVM_DUPLEX_VHF_MIN_MHZ,
+  MMDVM_DUPLEX_VHF_MAX_MHZ,
+  MMDVM_DUPLEX_UHF_MIN_MHZ,
+  MMDVM_DUPLEX_UHF_MAX_MHZ,
   type MMDVMChannelEntry,
 } from '../../src/services/mmdvmChannels';
 
 const entries: MMDVMChannelEntry[] = [
-  { channelName: 'Local', talkGroupName: 'Local', talkGroupId: 9 },
-  { channelName: 'Canada', talkGroupName: 'Canada', talkGroupId: 302 },
+  { channelName: 'Local', contactId: 1 },
+  { channelName: 'Canada', contactId: 2 },
 ];
 
 const baseOptions = {
   frequencyMhz: 433.0,
   entries,
   firstChannelNumber: 1,
-  firstContactId: 1,
   dmrRadioIdIndex: undefined,
 };
 
@@ -37,11 +41,37 @@ describe('isValidMMDVMFrequency', () => {
   });
 });
 
+describe('isValidMMDVMDuplexFrequency', () => {
+  it('accepts frequencies in the 2m (VHF) range', () => {
+    expect(isValidMMDVMDuplexFrequency(MMDVM_DUPLEX_VHF_MIN_MHZ)).toBe(true);
+    expect(isValidMMDVMDuplexFrequency(MMDVM_DUPLEX_VHF_MAX_MHZ)).toBe(true);
+    expect(isValidMMDVMDuplexFrequency(146.52)).toBe(true);
+  });
+
+  it('accepts frequencies in the 70cm (UHF) range', () => {
+    expect(isValidMMDVMDuplexFrequency(MMDVM_DUPLEX_UHF_MIN_MHZ)).toBe(true);
+    expect(isValidMMDVMDuplexFrequency(MMDVM_DUPLEX_UHF_MAX_MHZ)).toBe(true);
+    expect(isValidMMDVMDuplexFrequency(440.0)).toBe(true);
+  });
+
+  it('rejects frequencies in the gap between VHF and UHF', () => {
+    expect(isValidMMDVMDuplexFrequency(200.0)).toBe(false);
+  });
+
+  it('rejects frequencies outside both ranges', () => {
+    expect(isValidMMDVMDuplexFrequency(MMDVM_DUPLEX_VHF_MIN_MHZ - 1)).toBe(false);
+    expect(isValidMMDVMDuplexFrequency(MMDVM_DUPLEX_UHF_MAX_MHZ + 1)).toBe(false);
+  });
+
+  it('rejects NaN', () => {
+    expect(isValidMMDVMDuplexFrequency(NaN)).toBe(false);
+  });
+});
+
 describe('generateMMDVMChannels', () => {
-  it('creates one channel and one contact per entry', () => {
+  it('creates one channel per entry', () => {
     const result = generateMMDVMChannels(baseOptions);
     expect(result.channels).toHaveLength(entries.length);
-    expect(result.contacts).toHaveLength(entries.length);
   });
 
   it('assigns sequential channel numbers starting from firstChannelNumber', () => {
@@ -50,52 +80,28 @@ describe('generateMMDVMChannels', () => {
     expect(result.channels[1].number).toBe(51);
   });
 
-  it('assigns sequential contact IDs starting from firstContactId', () => {
-    const result = generateMMDVMChannels({ ...baseOptions, firstContactId: 100 });
-    expect(result.contacts[0].id).toBe(100);
-    expect(result.contacts[1].id).toBe(101);
-  });
-
-  it('links each channel to its contact', () => {
+  it("links each channel to its entry's contactId directly (contact resolution is the caller's job)", () => {
     const result = generateMMDVMChannels(baseOptions);
     result.channels.forEach((ch, i) => {
-      expect(ch.contactId).toBe(result.contacts[i].id);
+      expect(ch.contactId).toBe(entries[i].contactId);
     });
-  });
-
-  it('creates a single zone containing all channel numbers', () => {
-    const result = generateMMDVMChannels(baseOptions);
-    expect(result.zone).toBeDefined();
-    expect(result.zone.channels).toHaveLength(entries.length);
-    result.channels.forEach(ch => {
-      expect(result.zone.channels).toContain(ch.number);
-    });
-  });
-
-  it('uses provided zone name', () => {
-    const result = generateMMDVMChannels({ ...baseOptions, zoneName: 'MyHotspot' });
-    expect(result.zone.name).toBe('MyHotspot');
-  });
-
-  it('defaults zone name to MMDVM when not provided', () => {
-    const result = generateMMDVMChannels(baseOptions);
-    expect(result.zone.name).toBe('MMDVM');
-  });
-
-  it('truncates zone name to 16 characters', () => {
-    const result = generateMMDVMChannels({ ...baseOptions, zoneName: 'A'.repeat(30) });
-    expect(result.zone.name.length).toBeLessThanOrEqual(16);
   });
 
   it('truncates channel names to 16 characters', () => {
     const longEntries: MMDVMChannelEntry[] = [
-      { channelName: 'A'.repeat(30), talkGroupName: 'TG', talkGroupId: 1 },
+      { channelName: 'A'.repeat(30), contactId: 1 },
     ];
     const result = generateMMDVMChannels({ ...baseOptions, entries: longEntries });
     expect(result.channels[0].name.length).toBeLessThanOrEqual(16);
   });
 
-  it('uses rx=tx (simplex) frequency', () => {
+  it('defaults an empty channel name to "MMDVM N"', () => {
+    const blankEntries: MMDVMChannelEntry[] = [{ channelName: '', contactId: 1 }];
+    const result = generateMMDVMChannels({ ...baseOptions, entries: blankEntries });
+    expect(result.channels[0].name).toBe('MMDVM 1');
+  });
+
+  it('uses rx=tx (simplex) frequency when no TX frequency is given', () => {
     const result = generateMMDVMChannels({ ...baseOptions, frequencyMhz: 433.5 });
     result.channels.forEach(ch => {
       expect(ch.rxFrequency).toBe(433.5);
@@ -103,7 +109,17 @@ describe('generateMMDVMChannels', () => {
     });
   });
 
-  it('throws on invalid frequency', () => {
+  it('treats an explicit txFrequencyMhz equal to frequencyMhz as simplex, not duplex', () => {
+    // isDuplex requires txFrequencyMhz to differ from frequencyMhz — an equal value should
+    // still validate against the narrow 431-435 MHz simplex range, not the wider duplex bands.
+    expect(() => generateMMDVMChannels({
+      ...baseOptions,
+      frequencyMhz: 146.52,
+      txFrequencyMhz: 146.52,
+    })).toThrow();
+  });
+
+  it('throws on invalid simplex frequency', () => {
     expect(() => generateMMDVMChannels({ ...baseOptions, frequencyMhz: 100 })).toThrow();
   });
 
@@ -115,6 +131,95 @@ describe('generateMMDVMChannels', () => {
     const result = generateMMDVMChannels({ ...baseOptions, dmrRadioIdIndex: 2 });
     result.channels.forEach(ch => {
       expect(ch.dmrRadioIdIndex).toBe(2);
+    });
+  });
+
+  it('defaults color code to 1 when not provided', () => {
+    const result = generateMMDVMChannels(baseOptions);
+    result.channels.forEach(ch => {
+      expect(ch.colorCode).toBe(1);
+    });
+  });
+
+  it('uses the provided color code', () => {
+    const result = generateMMDVMChannels({ ...baseOptions, colorCode: 5 });
+    result.channels.forEach(ch => {
+      expect(ch.colorCode).toBe(5);
+    });
+  });
+
+  describe('duplex', () => {
+    it('uses separate RX and TX frequencies when txFrequencyMhz differs from frequencyMhz', () => {
+      const result = generateMMDVMChannels({
+        ...baseOptions,
+        frequencyMhz: 146.52,
+        txFrequencyMhz: 146.94,
+      });
+      result.channels.forEach(ch => {
+        expect(ch.rxFrequency).toBe(146.52);
+        expect(ch.txFrequency).toBe(146.94);
+      });
+    });
+
+    it('accepts VHF duplex frequencies outside the simplex calling range', () => {
+      expect(() => generateMMDVMChannels({
+        ...baseOptions,
+        frequencyMhz: 146.52,
+        txFrequencyMhz: 146.94,
+      })).not.toThrow();
+    });
+
+    it('accepts UHF duplex frequencies outside the simplex calling range', () => {
+      expect(() => generateMMDVMChannels({
+        ...baseOptions,
+        frequencyMhz: 440.0,
+        txFrequencyMhz: 445.0,
+      })).not.toThrow();
+    });
+
+    it('throws when the RX frequency is outside both duplex ranges', () => {
+      expect(() => generateMMDVMChannels({
+        ...baseOptions,
+        frequencyMhz: 200.0,
+        txFrequencyMhz: 440.0,
+      })).toThrow();
+    });
+
+    it('throws when the TX frequency is outside both duplex ranges', () => {
+      expect(() => generateMMDVMChannels({
+        ...baseOptions,
+        frequencyMhz: 146.52,
+        txFrequencyMhz: 200.0,
+      })).toThrow();
+    });
+  });
+
+  describe('timeslot', () => {
+    // Storage encoding: slotOperation 0 = TS1, 1 = TS2. When no timeslot is specified
+    // anywhere, the current implementation's default resolves to TS2 (1) — asserting the
+    // actual behavior here, not a claim that TS2-by-default is necessarily the ideal choice.
+    it('defaults slotOperation to TS2 (1) when no timeslot is given at all', () => {
+      const result = generateMMDVMChannels(baseOptions);
+      result.channels.forEach(ch => {
+        expect(ch.slotOperation).toBe(1);
+      });
+    });
+
+    it('applies the top-level timeslot as the default for entries without their own', () => {
+      const result = generateMMDVMChannels({ ...baseOptions, timeslot: 1 });
+      result.channels.forEach(ch => {
+        expect(ch.slotOperation).toBe(0); // TS1 -> 0
+      });
+    });
+
+    it('lets a per-entry timeslot override the top-level default', () => {
+      const mixedEntries: MMDVMChannelEntry[] = [
+        { channelName: 'TS1 entry', contactId: 1, timeslot: 1 },
+        { channelName: 'TS2 entry', contactId: 2, timeslot: 2 },
+      ];
+      const result = generateMMDVMChannels({ ...baseOptions, entries: mixedEntries, timeslot: 2 });
+      expect(result.channels[0].slotOperation).toBe(0); // per-entry TS1 overrides top-level TS2
+      expect(result.channels[1].slotOperation).toBe(1); // TS2 -> 1
     });
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,16 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { viteSingleFile } from 'vite-plugin-singlefile'
 import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
 import { inlineFavicon } from './vite-plugin-inline-favicon'
+
+// package.json's version — the same number electron-builder ships in its NSIS/portable
+// installers and electron-updater compares against latest.yml, so this is the one figure
+// that actually confirms which build (web or desktop) you're running.
+function getAppVersion(): string {
+  const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'));
+  return pkg.version;
+}
 
 // Get commit hash from environment or git
 function getCommitHash(): string {
@@ -23,11 +32,13 @@ export default defineConfig(({ mode }) => {
   const isSingleFile = mode === 'singlefile'
   const commitHash = getCommitHash();
   const buildTime = new Date().toISOString();
-  
+  const appVersion = getAppVersion();
+
   return {
     define: {
       __COMMIT_HASH__: JSON.stringify(commitHash),
       __BUILD_TIME__: JSON.stringify(buildTime),
+      __APP_VERSION__: JSON.stringify(appVersion),
     },
     plugins: [
       react(),


### PR DESCRIPTION
Talk Groups, Smart Import, CSV, and DMR Repeater wizard fixes

Bug fixes:
- Fix write-time channel filter silently corrupting zones/scan lists (#158)
- Preserve byte 0x1A bits 1-0 on every channel write (#159)
- Fix Smart Import wizard silently dropping/overwriting channels (#160)
- Fix Talk Groups reads/writes being capped at ~170 entries instead of the full 800 across all 5 memory blocks (#163)
- Fix blank TX frequency defaulting to a bogus 1666.666 MHz instead of simplex (#164)

Features:
- Expose live talkaround state in the channel editor and table (#157)
- Full CSV export/import (#161)
- Talk Groups CSV support (#162)
- DMR Repeaters wizard: generate channels per static talk group, with review/select before commit (#165, #166)

Replaces #157–#166, which I'll close in favor of this combined PR.