### PR TITLE
The DM-32's calibration block can never be written

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,7 @@ Import sources (`components/import/sources/*.tsx`) all render `<SelectAllButtons
 - `rxGroupListId` is masked to 6 bits on parse but not clamped on encode — silent truncation risk.
 - DCS encoding uses BCD digit nibbles with 0x80 (normal) / 0xC0 (inverted) bases, per `DM32-Protocol-Spec/06-ENCODING.md`. Decode and encode were *both* wrong and mutually consistent for D0xx codes for a long time, which is why round-trip tests didn't catch it. Now covered over all 104 codes × both polarities — **if you touch the codec, keep those tests green.**
 - `concatenateCachedBlocks` silently shifts data if a block is missing from cache (open TODO).
+- **The calibration block (metadata 0x02) is never written.** `dm32uv/writeGuard.ts` checks every write in the connection's only two write methods, `writeMemory` and `writeMemoryBlock`, before a byte is sent. It refuses a write that overlaps a scanned calibration block, lands in the config memory without a block scan or at an address the scan did not report, or would tag a block 0x02; with no memory layout known, nothing is written. The codeplug, contact and boot-image writes also check all their blocks first, so a refusal never leaves a partial write. Never add a write path around those two methods.
 - **Scan lists (fixed + hardware-verified 2026-08-07 via live CPS↔NeonPlug round-trips):**
   channel byte 0x19 stores the scan list ref in **bits 5-0** (1-indexed, 0=None) — the spec's
   "bits 5-2" is wrong. Membership is the `+0x1A` list only, **max 15**; scan entry `+0x0F` is

--- a/src/radios/dm32uv/connection.ts
+++ b/src/radios/dm32uv/connection.ts
@@ -6,6 +6,7 @@
 import type { WebSerialPort } from './types';
 import { CONNECTION } from './constants';
 import { log } from '../../utils/protocolLogger';
+import { assertBlockWritable, type WriteGuardContext } from './writeGuard';
 
 // Re-export for backward compatibility
 export type SerialPort = WebSerialPort;
@@ -42,6 +43,17 @@ export class DM32Connection {
   private port: WebSerialPort | null = null;
   private readBuffer: Uint8Array = new Uint8Array(0); // Persistent read buffer
   private isReading: boolean = false; // Prevent concurrent reads
+
+  /**
+   * Checked by both write methods before a byte is sent. With none installed,
+   * nothing is written: see writeGuard.ts.
+   */
+  private writeGuard: (() => WriteGuardContext | null) | null = null;
+
+  /** Install the check every write goes through. DM32UVProtocol does this for each connection it makes. */
+  setWriteGuard(provider: () => WriteGuardContext | null): void {
+    this.writeGuard = provider;
+  }
 
   async connect(port: WebSerialPort): Promise<void> {
     // Clear any leftover state from previous connections
@@ -258,6 +270,7 @@ export class DM32Connection {
     if (data.length !== 4096) {
       throw new Error(`Write data must be exactly 4096 bytes, got ${data.length}`);
     }
+    assertBlockWritable({ address, length: data.length, data, metadata }, this.writeGuard?.() ?? null);
 
     // Write command format: 0x57 ("W") <addr:3> <0x00> <0x10> <data:4096>
     // The metadata byte is INSIDE the data block at offset 0xFFF, not sent separately
@@ -361,6 +374,7 @@ export class DM32Connection {
     if (data.length !== 2048 && data.length !== 4096) {
       throw new Error(`Boot image block must be 2048 or 4096 bytes, got ${data.length}`);
     }
+    assertBlockWritable({ address, length: data.length, data }, this.writeGuard?.() ?? null);
     const addrBytes = new Uint8Array([
       address & 0xff,
       (address >> 8) & 0xff,

--- a/src/radios/dm32uv/protocol.ts
+++ b/src/radios/dm32uv/protocol.ts
@@ -24,6 +24,7 @@ import { METADATA, BLOCK_SIZE, OFFSET, VFRAME, CONNECTION, LIMITS } from './cons
 import { BOOT_IMAGE } from '../../utils/bootImage';
 import { getContactCapacityWithFallback } from '../../utils/firmware';
 import { withTimeout } from './connection';
+import { assertBlockWritable, type WriteGuardContext } from './writeGuard';
 import { log } from '../../utils/protocolLogger';
 
 /**
@@ -380,6 +381,9 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     // Note: DM32Connection.connect() handles the post-open INIT_DELAY internally
     this.port = port;
     this.connection = new DM32Connection();
+    // Every write this connection sends is checked against the memory layout and
+    // block map as they stand at that moment: see writeGuard.ts.
+    this.connection.setWriteGuard(() => this.writeGuardContext());
     // Each request/response in connect() has its own 2s timeout (per-request basis)
     await this.connection.connect(port);
 
@@ -425,6 +429,48 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     // Enter programming mode
     // Each request/response in enterProgrammingMode() has its own 2s timeout
     await this.connection.enterProgrammingMode();
+  }
+
+  /**
+   * What every write is checked against (writeGuard.ts). Read at the moment of
+   * each write, so a fresh metadata scan is seen without anything having to hand
+   * it over. Null until the memory layout is known, which refuses everything.
+   */
+  private writeGuardContext(): WriteGuardContext | null {
+    const layout = this.radioInfo?.memoryLayout;
+    if (!layout) return null;
+    return { configStart: layout.configStart, configEnd: layout.configEnd, blocks: this.discoveredBlocks };
+  }
+
+  /**
+   * Refuse a contact write before its first block if any block it would touch
+   * runs past the contact memory V-frame 0x0F reports, or is one the write guard
+   * refuses.
+   *
+   * writeContacts walks 4 KB blocks up from that range's start, one for every 44
+   * contacts, and nothing else checks where the walk ends: a long enough list
+   * would carry on into whatever memory follows.
+   */
+  private assertContactWriteFits(baseAddr: number, endAddr: number, contactCount: number): void {
+    const CONTACTS_PER_BLOCK = 44; // writeContacts' own layout
+    const firstBlockAddr = Math.floor(baseAddr / BLOCK_SIZE.STANDARD) * BLOCK_SIZE.STANDARD;
+    // The count header goes out even for an empty list, so there is always a block.
+    const blocks = Math.max(1, Math.ceil(contactCount / CONTACTS_PER_BLOCK));
+    const lastByte = firstBlockAddr + blocks * BLOCK_SIZE.STANDARD - 1;
+    if (lastByte > endAddr) {
+      const fit =
+        Math.max(0, Math.floor((endAddr + 1 - firstBlockAddr) / BLOCK_SIZE.STANDARD)) * CONTACTS_PER_BLOCK;
+      throw new Error(
+        `Refusing to write ${contactCount.toLocaleString()} contacts: they need ${blocks} blocks (4 KB each) ` +
+          `starting at 0x${firstBlockAddr.toString(16).toUpperCase()}, which runs past the end of the radio's ` +
+          `contact memory at 0x${endAddr.toString(16).toUpperCase()}. At most ${fit.toLocaleString()} fit. ` +
+          `Nothing was written.`
+      );
+    }
+    const guard = this.writeGuardContext();
+    for (let i = 0; i < blocks; i++) {
+      assertBlockWritable({ address: firstBlockAddr + i * BLOCK_SIZE.STANDARD, length: BLOCK_SIZE.STANDARD }, guard);
+    }
   }
 
   /**
@@ -1070,6 +1116,26 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     }
     const baseAddr = this.getBootImageBaseAddress();
     const fullBlocks = BOOT_IMAGE.FULL_BLOCKS;
+    // Every block checked before the first is sent. The base is V-frame 0x0E's,
+    // or a default when that is missing, and nothing else checks where it points.
+    // The image is pixels, not metadata blocks, so it must stay out of the config
+    // memory entirely.
+    const guard = this.writeGuardContext();
+    if (guard && baseAddr <= guard.configEnd && baseAddr + BOOT_IMAGE.SIZE - 1 >= guard.configStart) {
+      throw new Error(
+        `Refusing to write the boot image at 0x${baseAddr.toString(16).toUpperCase()}: it would overlap the ` +
+          `radio's config memory, where channels, settings and calibration live. Nothing was written.`
+      );
+    }
+    for (let i = 0; i < BOOT_IMAGE.BLOCKS; i++) {
+      assertBlockWritable(
+        {
+          address: baseAddr + i * BLOCK_SIZE.STANDARD,
+          length: i < fullBlocks ? BLOCK_SIZE.STANDARD : BOOT_IMAGE.LAST_CHUNK_SIZE,
+        },
+        guard
+      );
+    }
     for (let i = 0; i < fullBlocks; i++) {
       const progress = Math.floor(((i + 1) / BOOT_IMAGE.BLOCKS) * 100);
       this.onProgress?.(progress, `Writing boot image block ${i + 1} of ${BOOT_IMAGE.BLOCKS}...`);
@@ -1952,6 +2018,8 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
     
     const ENTRY_SIZE = 0x5C; // 92 bytes per contact
     
+    this.assertContactWriteFits(baseAddr, endAddr, contacts.length);
+
     // Write contact count in first 16 bytes (4 bytes count + 12 bytes padding)
     // Count is at baseAddr, contacts start at baseAddr + 0x10
     this.onProgress?.(5, `Writing contact count header...`);
@@ -3802,6 +3870,17 @@ export class DM32UVProtocol extends BaseDigitalProtocol implements DM32Protocol 
       log.debug(`${metadataHex} at ${addressHex} (${block.data.length} bytes)`, 'Protocol');
     }
     
+    // Every block checked before the first is sent. The connection refuses a bad
+    // block by itself, but only when it gets to it, and by then the blocks ahead
+    // of it are on the radio.
+    const guard = this.writeGuardContext();
+    for (const block of finalBlocksToWrite) {
+      assertBlockWritable(
+        { address: block.address, length: block.data.length, data: block.data, metadata: block.metadata },
+        guard
+      );
+    }
+
     // Step 5: Write all blocks to radio in the correct order
     this.onProgress?.(60, `Writing ${finalBlocksToWrite.length} blocks to radio in correct order...`);
     

--- a/src/radios/dm32uv/writeGuard.ts
+++ b/src/radios/dm32uv/writeGuard.ts
@@ -1,0 +1,91 @@
+/**
+ * The DM-32's calibration block is never written.
+ *
+ * Calibration is the radio's factory frequency and power adjustment: one 4 KB
+ * block in the main config memory, tagged metadata 0x02. NeonPlug reads it and
+ * has no reason ever to send it back, but until 2026-09-12 nothing stopped a
+ * write reaching it. Every writer chose its own addresses. The codeplug write
+ * looks its blocks up by metadata; the contact and boot-image writes walk
+ * addresses the radio reports and never check what is there. Protection rested
+ * on each of them choosing correctly.
+ *
+ * So every write is checked here, from the only two methods that send a DM-32
+ * write command, before a byte goes out. A write is refused when:
+ *
+ *   - there is no guard context: no memory layout from V-frame 0x0A;
+ *   - it overlaps a block the metadata scan found tagged 0x02;
+ *   - it lands in the config memory when no scan has run, or at an address the
+ *     scan did not report. Calibration lives there and its address is not
+ *     fixed, so not knowing where it is means not writing there;
+ *   - it would tag a config block 0x02, by its metadata or its own byte 0xFFF.
+ *
+ * Outside the config memory, byte 0xFFF is data rather than a block tag (a
+ * contact record, a boot image pixel), so only the overlap rule applies there.
+ * The limit of this: the scan covers the config memory alone, so a calibration
+ * block the radio kept anywhere else would be invisible to it.
+ */
+
+import { BLOCK_SIZE, METADATA } from './constants';
+import type { MemoryBlock } from './memory';
+
+export interface WriteGuardContext {
+  /** V-frame 0x0A's main config memory. Every metadata block, calibration included, is in it. */
+  configStart: number;
+  configEnd: number;
+  /** The block map from the last metadata scan, or restored from the read. Empty when there has been none. */
+  blocks: readonly MemoryBlock[];
+}
+
+export interface BlockWrite {
+  address: number;
+  length: number;
+  /** The bytes, when known: byte 0xFFF is the tag the block is left with. */
+  data?: Uint8Array;
+  metadata?: number;
+}
+
+const hex = (address: number) => `0x${address.toString(16).padStart(6, '0').toUpperCase()}`;
+
+/** Throws, naming the rule, if `write` could touch the calibration block. */
+export function assertBlockWritable(write: BlockWrite, ctx: WriteGuardContext | null): void {
+  const at = hex(write.address);
+  if (!ctx) {
+    throw new Error(
+      `Refusing to write ${at}: the radio's memory layout is unknown, so the calibration block cannot be ruled out.`
+    );
+  }
+
+  const first = write.address;
+  const last = write.address + Math.max(write.length, 1) - 1;
+
+  const calibration = ctx.blocks.find(
+    (b) =>
+      b.metadata === METADATA.CALIBRATION &&
+      first <= b.address + BLOCK_SIZE.STANDARD - 1 &&
+      last >= b.address
+  );
+  if (calibration) {
+    throw new Error(
+      `Refusing to write ${at}: it would overwrite the radio's calibration data at ${hex(calibration.address)}, which NeonPlug never writes.`
+    );
+  }
+
+  if (first > ctx.configEnd || last < ctx.configStart) return;
+
+  if (ctx.blocks.length === 0) {
+    throw new Error(
+      `Refusing to write ${at}: it is in the radio's config memory, and without a block scan the calibration block's location is unknown.`
+    );
+  }
+  if (!ctx.blocks.some((b) => b.address === write.address)) {
+    throw new Error(
+      `Refusing to write ${at}: it is in the radio's config memory but is not a block the scan reported.`
+    );
+  }
+  const tag = write.data && write.data.length > 0xfff ? write.data[0xfff] : undefined;
+  if (write.metadata === METADATA.CALIBRATION || tag === METADATA.CALIBRATION) {
+    throw new Error(
+      `Refusing to write ${at}: the block would be tagged as calibration data (metadata 0x02), which NeonPlug never writes.`
+    );
+  }
+}

--- a/tests/unit/dm32WriteGuard.test.ts
+++ b/tests/unit/dm32WriteGuard.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { assertBlockWritable, type WriteGuardContext } from '../../src/radios/dm32uv/writeGuard';
+import { DM32Connection } from '../../src/radios/dm32uv/connection';
+import { DM32UVProtocol } from '../../src/radios/dm32uv/protocol';
+import { VFRAME } from '../../src/radios/dm32uv/constants';
+import type { MemoryBlock } from '../../src/radios/dm32uv/memory';
+import { BOOT_IMAGE } from '../../src/utils/bootImage';
+import type { Contact, ScanList } from '../../src/models';
+
+/**
+ * The DM-32's calibration block is never written (writeGuard.ts).
+ *
+ * Calibration is the radio's factory frequency and power adjustment. Nothing in
+ * NeonPlug has a reason to write it, and until 2026-09-12 nothing stopped a
+ * write reaching it either: each writer picked its own addresses, and the only
+ * protection was that they picked correctly. These hold every refusal rule,
+ * that the connection refuses before a byte is sent, and that the codeplug,
+ * contact and boot-image writes refuse before their FIRST block, so a refusal
+ * never leaves a partial write behind.
+ */
+
+const CONFIG_START = 0x001000;
+const CONFIG_END = 0x008fff;
+const CALIBRATION = 0x003000;
+
+const blockAt = (address: number, metadata: number, type: MemoryBlock['type']): MemoryBlock => ({
+  address,
+  metadata,
+  type,
+});
+
+/** A small radio whose calibration block sits between the zone block and the scan list block. */
+const RADIO: MemoryBlock[] = [
+  blockAt(0x001000, 0x12, 'channel'),
+  blockAt(0x002000, 0x5c, 'zone'),
+  blockAt(CALIBRATION, 0x02, 'calibration'),
+  blockAt(0x004000, 0x11, 'scan'),
+  blockAt(0x005000, 0x04, 'vfo'),
+  blockAt(0x006000, 0xff, 'empty'),
+  blockAt(0x007000, 0xff, 'empty'),
+  blockAt(0x008000, 0xff, 'empty'),
+];
+
+const context = (blocks: readonly MemoryBlock[] = RADIO): WriteGuardContext => ({
+  configStart: CONFIG_START,
+  configEnd: CONFIG_END,
+  blocks,
+});
+
+/** A 4 KB block whose metadata byte (0xFFF) is `tag`. */
+function blockData(tag: number): Uint8Array {
+  const data = new Uint8Array(0x1000).fill(0xff);
+  data[0xfff] = tag;
+  return data;
+}
+
+describe('assertBlockWritable', () => {
+  it('refuses everything when the memory layout is unknown', () => {
+    expect(() => assertBlockWritable({ address: 0x278000, length: 0x1000 }, null)).toThrow(
+      /memory layout is unknown/
+    );
+  });
+
+  it('refuses the calibration block by address, whatever the write says it is', () => {
+    expect(() =>
+      assertBlockWritable({ address: CALIBRATION, length: 0x1000, data: blockData(0x12), metadata: 0x12 }, context())
+    ).toThrow(/calibration data at 0x003000/);
+  });
+
+  it('refuses a write that only overlaps the calibration block', () => {
+    expect(() => assertBlockWritable({ address: 0x002800, length: 0x1000 }, context())).toThrow(
+      /calibration data at 0x003000/
+    );
+  });
+
+  it('refuses tagging a config block as calibration, by metadata or by its own byte 0xFFF', () => {
+    expect(() => assertBlockWritable({ address: 0x004000, length: 0x1000, metadata: 0x02 }, context())).toThrow(
+      /tagged as calibration/
+    );
+    expect(() =>
+      assertBlockWritable({ address: 0x004000, length: 0x1000, data: blockData(0x02), metadata: 0x11 }, context())
+    ).toThrow(/tagged as calibration/);
+  });
+
+  it('refuses the config memory when no block scan has run', () => {
+    expect(() =>
+      assertBlockWritable({ address: 0x004000, length: 0x1000, data: blockData(0x11), metadata: 0x11 }, context([]))
+    ).toThrow(/without a block scan/);
+  });
+
+  it('refuses a config address the scan did not report', () => {
+    const withoutSettings = RADIO.filter((b) => b.address !== 0x005000);
+    expect(() => assertBlockWritable({ address: 0x005000, length: 0x1000 }, context(withoutSettings))).toThrow(
+      /not a block the scan reported/
+    );
+  });
+
+  it('allows a scanned block that is not calibration', () => {
+    expect(() =>
+      assertBlockWritable({ address: 0x004000, length: 0x1000, data: blockData(0x11), metadata: 0x11 }, context())
+    ).not.toThrow();
+  });
+
+  it('leaves memory outside the config range alone, even without a scan', () => {
+    // Contacts and the boot image live out here, and their byte 0xFFF is data
+    // rather than a block tag: a boot image pixel of 0x02 is not calibration.
+    expect(() => assertBlockWritable({ address: 0x278000, length: 0x1000 }, context([]))).not.toThrow();
+    expect(() =>
+      assertBlockWritable({ address: 0x150000, length: 0x1000, data: blockData(0x02), metadata: 0x02 }, context())
+    ).not.toThrow();
+  });
+});
+
+/** The write commands (0x57) that reached the serial port, by address. */
+type Sent = number[];
+
+function recordWrites(target: object, sent: Sent) {
+  const serial = target as unknown as {
+    write(data: Uint8Array): Promise<void>;
+    readBytes(count: number): Promise<Uint8Array>;
+  };
+  vi.spyOn(serial, 'write').mockImplementation(async (data: Uint8Array) => {
+    if (data[0] === 0x57) sent.push(data[1] | (data[2] << 8) | (data[3] << 16));
+  });
+  vi.spyOn(serial, 'readBytes').mockResolvedValue(new Uint8Array([0x06]));
+}
+
+describe('DM32Connection checks before sending a byte', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('writes nothing with no guard installed', async () => {
+    const connection = new DM32Connection();
+    const sent: Sent = [];
+    recordWrites(connection, sent);
+    await expect(connection.writeMemory(0x004000, blockData(0x11), 0x11)).rejects.toThrow(/memory layout is unknown/);
+    await expect(connection.writeMemoryBlock(0x150000, new Uint8Array(2048))).rejects.toThrow(
+      /memory layout is unknown/
+    );
+    expect(sent).toEqual([]);
+  });
+
+  it('refuses the calibration block through both write methods', async () => {
+    const connection = new DM32Connection();
+    const sent: Sent = [];
+    recordWrites(connection, sent);
+    connection.setWriteGuard(() => context());
+    await expect(connection.writeMemory(CALIBRATION, blockData(0x02), 0x02)).rejects.toThrow(/calibration/);
+    await expect(connection.writeMemoryBlock(CALIBRATION, new Uint8Array(2048))).rejects.toThrow(/calibration/);
+    expect(sent).toEqual([]);
+  });
+
+  it('sends a block the guard allows', async () => {
+    const connection = new DM32Connection();
+    const sent: Sent = [];
+    recordWrites(connection, sent);
+    connection.setWriteGuard(() => context());
+    await connection.writeMemory(0x004000, blockData(0x11), 0x11);
+    expect(sent).toEqual([0x004000]);
+  });
+});
+
+/** A V-frame payload that holds a range: two little-endian u32s. */
+function range(start: number, end: number): Uint8Array {
+  const bytes = new Uint8Array(8);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, start, true);
+  view.setUint32(4, end, true);
+  return bytes;
+}
+
+/**
+ * A DM32UVProtocol connected through its real connectWithPort, so the guard is
+ * installed by production code. Only the serial I/O is faked: metadata reads
+ * answer from `radio`, and writes are recorded and acknowledged.
+ */
+async function connectedRadio(radio: MemoryBlock[], vframes: Array<[number, Uint8Array]> = []) {
+  const sent: Sent = [];
+  const frames = new Map<number, Uint8Array>([[VFRAME.MEMORY_LAYOUT, range(CONFIG_START, CONFIG_END)], ...vframes]);
+  vi.spyOn(DM32Connection.prototype, 'connect').mockResolvedValue(undefined);
+  vi.spyOn(DM32Connection.prototype, 'queryVFrames').mockResolvedValue(frames);
+  vi.spyOn(DM32Connection.prototype, 'enterProgrammingMode').mockResolvedValue(undefined);
+  vi.spyOn(DM32Connection.prototype, 'readMemory').mockImplementation(async (address: number, length: number) => {
+    const block = radio.find((b) => b.address === Math.floor(address / 0x1000) * 0x1000);
+    return new Uint8Array(length).fill(block ? block.metadata : 0xff);
+  });
+  recordWrites(DM32Connection.prototype, sent);
+
+  const protocol = new DM32UVProtocol();
+  await (protocol as unknown as { connectWithPort(port: unknown): Promise<void> }).connectWithPort({});
+  return { protocol, sent };
+}
+
+const cachedBlocks = (radio: MemoryBlock[]) =>
+  radio
+    .filter((b) => b.type !== 'empty')
+    .map((b) => ({ metadata: b.metadata, address: b.address, data: blockData(b.metadata) }));
+
+const oneScanList: ScanList = { name: 'SL1', channels: [], ctcScanMode: 0, scanTxMode: 0 };
+
+describe('DM-32 writes check every block before their first', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('a codeplug write never sends the calibration block', async () => {
+    const { protocol, sent } = await connectedRadio(RADIO);
+    protocol.cachedBlockData = cachedBlocks(RADIO);
+    await protocol.writeAllData([], [], [oneScanList]);
+    expect(sent).not.toContain(CALIBRATION);
+    expect(sent).toEqual([0x002000, 0x004000]);
+  });
+
+  it('a codeplug write that would reach calibration sends nothing, not even the blocks ahead of it', async () => {
+    const { protocol, sent } = await connectedRadio(RADIO);
+    protocol.cachedBlockData = cachedBlocks(RADIO);
+    // Stand in for a writer bug: the guard's map says the scan list block is calibration.
+    const doctored = RADIO.map((b) => (b.address === 0x004000 ? blockAt(0x004000, 0x02, 'calibration') : b));
+    vi.spyOn(
+      protocol as unknown as { writeGuardContext(): WriteGuardContext | null },
+      'writeGuardContext'
+    ).mockReturnValue(context(doctored));
+    await expect(protocol.writeAllData([], [], [oneScanList])).rejects.toThrow(/calibration/);
+    expect(sent).toEqual([]);
+  });
+
+  it('a contact list that runs past the contact memory writes nothing', async () => {
+    const { protocol, sent } = await connectedRadio(RADIO, [[VFRAME.CONTACTS, range(0x278000, 0x278fff)]]);
+    const contacts = Array.from({ length: 45 }, (_, i) => ({ id: i + 1, name: `C${i + 1}`, dmrId: 3100000 + i }) as Contact);
+    await expect(protocol.writeContacts(contacts)).rejects.toThrow(/past the end of the radio's contact memory/);
+    await expect(protocol.writeContacts(contacts)).rejects.toThrow(/At most 44 fit/);
+    expect(sent).toEqual([]);
+  });
+
+  it('a contact range reported inside the config memory writes nothing', async () => {
+    const { protocol, sent } = await connectedRadio(RADIO, [[VFRAME.CONTACTS, range(CALIBRATION, CONFIG_END)]]);
+    await expect(protocol.writeContacts([{ id: 1, name: 'C1', dmrId: 3100000 } as Contact])).rejects.toThrow(
+      /config memory/
+    );
+    expect(sent).toEqual([]);
+  });
+
+  it('a boot image aimed at the config memory writes nothing', async () => {
+    const { protocol, sent } = await connectedRadio(RADIO, [[0x0e, range(0x002000, 0x0fffff)]]);
+    await expect(protocol.writeBootImage(new Uint8Array(BOOT_IMAGE.SIZE))).rejects.toThrow(
+      /overlap the radio's config memory/
+    );
+    expect(sent).toEqual([]);
+  });
+
+  it('boot image pixels are not mistaken for a calibration tag', async () => {
+    const { protocol, sent } = await connectedRadio(RADIO, [[0x0e, range(0x150000, 0x175fff)]]);
+    const image = new Uint8Array(BOOT_IMAGE.SIZE);
+    for (let i = 0; i < BOOT_IMAGE.FULL_BLOCKS; i++) image[i * 0x1000 + 0xfff] = 0x02;
+    vi.useFakeTimers();
+    const done = protocol.writeBootImage(image);
+    await vi.runAllTimersAsync();
+    await done;
+    expect(sent).toHaveLength(BOOT_IMAGE.BLOCKS);
+  });
+});


### PR DESCRIPTION
## Why

The DM-32's calibration block (metadata 0x02, the radio's factory frequency and power adjustment) must never be written. Nothing enforced that. Every DM-32 write goes through `DM32Connection.writeMemory` or `writeMemoryBlock`, and neither checked the address.

What the audit found (`src/radios/dm32uv/protocol.ts`, `connection.ts`, `memory.ts`):

- **Codeplug write (`writeAllData` and the writers the hook runs after it):** every block comes from a metadata lookup on a fresh scan, and none looks up 0x02. Safe today, but only because each writer picks correctly.
- **Scan-list fix (#156):** it resizes the scan-list buffer and changes its padding. Its writes still go only to scanned 0x11 blocks.
- **Contact write:** addresses are `V-frame 0x0F start + n × 4 KB` for `ceil(contacts / 44)` blocks. There was no end check and no look at what each block is. It reads each block and writes it back with that block's own metadata byte.
- **Boot image write:** 38 blocks from V-frame 0x0E's address, or 0x150000 if that V-frame is missing. Nothing checked where that lands.

## What changes

`src/radios/dm32uv/writeGuard.ts` is called from both connection write methods before a byte is sent. It refuses a write that:

1. overlaps a block the metadata scan found tagged 0x02;
2. lands in the config memory (V-frame 0x0A) with no block scan, or at an address the scan did not report;
3. would tag a config block 0x02, through its metadata or its own byte 0xFFF.

With no memory layout known, nothing is written. Outside the config memory, byte 0xFFF is data rather than a block tag, so only rule 1 applies there. That's what keeps boot image pixels of 0x02 from being refused.

- The protocol installs the guard in `connectWithPort`, the only place a connection is made. It reads the current layout and block map at each write.
- `writeAllData`, `writeContacts` and `writeBootImage` check every block before sending the first, so a refusal can't leave a partial write.
- `writeContacts` also refuses a list that would run past the end address V-frame 0x0F reports.
- `writeBootImage` also refuses an address range that overlaps the config memory.
- `CLAUDE.md` records the rule under the DM-32 quirks.

## Testing

- `tests/unit/dm32WriteGuard.test.ts`, 17 tests:
  - every refusal rule;
  - the connection refusing before anything reaches the serial port;
  - the codeplug, contact and boot-image writes, driven through the real `connectWithPort` with only the serial I/O faked. That includes a radio with calibration between the zone and scan-list blocks, and a writer bug aimed at calibration that must send nothing, not even the blocks ahead of it.
- Mutation-checked: 12 of 12 mutations fail at least one test. They cover each connection check, the wiring, the up-front checks, the contact limit, the boot image check, each guard rule, and the early return that prevents false positives.
- `npm test`: 135 files, 1,643 tests pass. `npm run build` is clean. No new lint findings in the touched files.

## Needs a DM-32

Nothing here has been run against a radio.

- [ ] Read, then write a small change: normal writes must still go through.
- [ ] Check where the contact memory ends (V-frame 0x0F in Diagnostics). With the spec's example range, 0x278000–0x6DBFFF, NeonPlug's 44-contacts-per-block layout fits 49,456 contacts, while the Contacts tab allows 50,000. A 50,000-contact write to that radio is now refused instead of running past the end.
- [ ] Related, not changed here: the spec addresses contacts contiguously (`base + index × 0x5C`), while NeonPlug restarts every 4 KB block at offset 0. Worth comparing against a real read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
